### PR TITLE
Eliminates the `pid.h` call from all the PWM examples of the SPIN board.

### DIFF
--- a/SPIN/PWM/duty_cycle_setting/main.cpp
+++ b/SPIN/PWM/duty_cycle_setting/main.cpp
@@ -33,7 +33,6 @@
 #include "TaskAPI.h"
 #include "TwistAPI.h"
 #include "SpinAPI.h"
-#include "pid.h"
 
 #include "zephyr/console/console.h"
 

--- a/SPIN/PWM/multiple_pwm/main.cpp
+++ b/SPIN/PWM/multiple_pwm/main.cpp
@@ -33,7 +33,6 @@
 #include "TaskAPI.h"
 #include "TwistAPI.h"
 #include "SpinAPI.h"
-#include "pid.h"
 
 #include "zephyr/console/console.h"
 

--- a/SPIN/PWM/phase_shift/main.cpp
+++ b/SPIN/PWM/phase_shift/main.cpp
@@ -33,7 +33,6 @@
 #include "TaskAPI.h"
 #include "TwistAPI.h"
 #include "SpinAPI.h"
-#include "pid.h"
 
 #include "zephyr/console/console.h"
 


### PR DESCRIPTION
**Description**

This PR updates the `main.cpp` files for the three PWM examples of the SPIN board. 

This solves issue #8 