### PR TITLE
Add workflows to build PlatformIO examples

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,0 +1,36 @@
+name: Build All Examples
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clone OwnTech Core
+        run: git clone --depth 1 https://github.com/owntech-foundation/core.git
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          python3 -m pip install --upgrade pip
+          pip3 install platformio
+      - name: Build examples
+        run: |
+          ./scripts/build_examples.sh
+      - name: Archive binaries
+        run: |
+          tar -czf binaries.tar.gz binaries
+      - uses: actions/upload-artifact@v3
+        with:
+          name: firmware-binaries
+          path: binaries.tar.gz
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: automatic-examples-${{ github.run_number }}
+          name: Build All Examples ${{ github.run_number }}
+          files: binaries.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -1,0 +1,33 @@
+name: Build Example
+
+on:
+  workflow_dispatch:
+    inputs:
+      example:
+        description: 'Example name as defined in library.json'
+        required: true
+        default: blinky
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clone OwnTech Core
+        run: git clone --depth 1 https://github.com/owntech-foundation/core.git
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          python3 -m pip install --upgrade pip
+          pip3 install platformio
+      - name: Build selected example
+        run: |
+          ./scripts/build_examples.sh ${{ github.event.inputs.example }}
+      - name: Archive binary
+        run: |
+          tar -czf binaries.tar.gz binaries
+      - uses: actions/upload-artifact@v3
+        with:
+          name: firmware-${{ github.event.inputs.example }}
+          path: binaries.tar.gz

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+EXAMPLE_REPO_DIR=$(pwd)
+CORE_DIR="core"
+OUTPUT_DIR="$EXAMPLE_REPO_DIR/binaries"
+
+if [ "$#" -eq 0 ]; then
+  EXAMPLES=$(jq -r '.examples[].name' "$EXAMPLE_REPO_DIR/library.json")
+else
+  EXAMPLES="$@"
+fi
+
+cd "$CORE_DIR"
+for EX in $EXAMPLES; do
+  BASE=$(jq -r --arg ex "$EX" '.examples[] | select(.name==$ex) | .base' "$EXAMPLE_REPO_DIR/library.json")
+  echo "Building $EX -> $BASE"
+  platformio run -t "$EX"
+  DEST="$OUTPUT_DIR/$BASE"
+  mkdir -p "$DEST"
+  cp .pio/build/*/firmware.mcuboot.bin "$DEST/firmware.mcuboot.bin"
+  echo "Stored firmware for $EX at $DEST"
+done


### PR DESCRIPTION
## Summary
- add CI script to build PlatformIO examples
- build all examples and upload binaries as release assets
- allow building a single example via workflow dispatch

## Testing
- `bash -n scripts/build_examples.sh`


------
https://chatgpt.com/codex/tasks/task_b_685c3174f53883218f3f5ef8dfad49da