### PR TITLE
Name update

### DIFF
--- a/OWNVERTER/BLDC_hall_sensor/README.md
+++ b/OWNVERTER/BLDC_hall_sensor/README.md
@@ -10,22 +10,22 @@ Here is a detailed explanation of the six sectors and the switching sequence for
 
 The six sectors are determined based on the Hall effect sensor outputs, which change as the rotor rotates. The Hall sensors provide three signals (H1, H2, H3), which can be interpreted as a 3-bit binary code. Each unique combination of these signals corresponds to one of the six sectors.
 
-In code this is done with :  
+In code, this is done with:  
 
 ``` hall_state = hall1_value + 2 * hall2_value + 4 * hall3_value; ```  
 
 Note that this should be adapted depending on the way phases and hall effect sensors are connected to the inverter. It might be necessary to permute the hall
 values to run the motor correctly.  
 
-### Controling the motor
+### Controlling the motor
 
-In each sequence we supply only two windings using two legs of the ownverter.
-Then if for example we supply phase A and B, the associate phase to phase voltage will
+In each sequence we supply only two windings using two legs of the OWNVERTER.
+Then, for example, if we supply phase A and B, the associated phase-to-phase voltage will
 be:
 
 $U_{AB} = (2.\textsf{duty\\\_cycle} - 1). U_{dc}$
 
-In this example duty_cycle can be increased or lowered by pressing `u` and `d` in the serial monitor. 
+In this example, duty_cycle can be increased or lowered by pressing `u` and `d` in the serial monitor. 
 It should directly affect motor speed.
 
 ### Commutation Sequence

--- a/OWNVERTER/FOC_hall_sensor/README.md
+++ b/OWNVERTER/FOC_hall_sensor/README.md
@@ -1,28 +1,28 @@
-# Field Oriented Control with hall Sensors.
+# Field Oriented Control with Hall sensors
 
 ## Introduction.
 
-This example show how to regulate the torque in a Permanent Magnet Synchonous Machine
+This example shows how to regulate the torque in a Permanent Magnet Synchronous Machine
 (PMSM) using a Field Oriented Control (FOC) algorithm. 
 
-The FOC is well adapted to PMSM with sinusoïdal back-emf (electro
-motive forces). The FOC algorithm generate smooth torque value. 
+The FOC is well adapted to PMSM with sinusoidal back-EMF (electromotive
+forces). The FOC algorithm generates smooth torque values. 
 The current regulators (Proportional-Integral) are in the _"dq"_ frame where values
 should be constant during steady state operation.
 
 To apply this technique we should have an acquisition of a continuous angle value [0, 2π[.
-But for _"cost"_ reasons or integrations with other algorithms (BLDC), some motor have
+But for _"cost"_ reasons or integrations with other algorithms (BLDC), some motors have
 only 3 discrete hall sensors value to indicate the rotor position.
 
-In this case we use a PLL (Phased-Lock-Loop) filter to _"build"_ a contiuous equivalent
+In this case we use a PLL (phase-locked loop) filter to _"build"_ a continuous equivalent
 angle from the 3 discrete signals. 
 
 ![](Images/foc_hall_scheme.png)
 
 ## Import libraries to use it.
 
-This example use some software components which are in the owntech `control_library`.
-then you must import it by inserting the following line in the `platformio.ini` file.
+This example uses some software components which are in the OwnTech `control_library`.
+Then you must import it by inserting the following line in the `platformio.ini` file.
 
 ```ini 
 lib_deps=
@@ -32,7 +32,7 @@ lib_deps=
 
 ## How the _"sector"_ table is built.
 
-According _"dq"_ transformation, the formula of the back emf should be :
+According to the _"dq"_ transformation, the formula of the back EMF should be:
 
 $E_{u} = - K_{fem}.\omega .sin(\theta)$
 
@@ -44,7 +44,7 @@ Where $\theta$ is the _"electric"_ angle and $\omega$ is the _"electric"_ pulsat
 
 For simplicity reasons we assume that the value $K_{fem}.\omega = 1$.
 
-Then the hall sensors must be synchronised with the hall sensors as the following:
+Then the Hall sensors must be synchronized with the back-EMF as follows:
 
 ![](Images/bemf_and_hall.png)
 
@@ -52,7 +52,7 @@ According these assumptions, we define a variable `hall_index` which is computed
 
 $hall_{index} = Hall_u . 2^0+ Hall_v . 2^1  + Hall_w . 2^2$
 
-We also define a `sector` variable which evolve like a quantification of a continuous
+We also define a `sector` variable which evolves like a quantification of a continuous
 angle value, then we can make a lookup table between these two variables.
 
 ![](Images/sector_and_hall_idx.png)
@@ -66,19 +66,19 @@ angle value, then we can make a lookup table between these two variables.
 | 4      | 5          |
 | 5      | 1          |
 
-## Use this example  
+## Use this example
 
-- Wire the motor hall effect sensors and power phase. The colors of the hall effect sensors should match the color of the power phase. 
-- Flash the example to the OwnVerter board.
+- Wire the motor Hall effect sensors and power phases. The colors of the Hall effect sensors should match the color of the power phases. 
+- Flash the example to the OWNVERTER board.
 - In the serial terminal press `p` to start the motor.
-- At that point, there is no torque reference as `Iq_ref` is equal to `0`
-- Increase the torque reference by pressing `u`. The torque reference is incremented by `0.1A` 
+- At that point, there is no torque reference as `Iq_ref` is equal to `0`.
+- Increase the torque reference by pressing `u`. The torque reference is incremented by `0.1 A`.
 - Increase the torque reference until the motor starts spinning.
-- Stop the motor by pressing `i`
-- You can retrieve live record by pressing `r`. It will download a data_record containing all declared scope values.
+- Stop the motor by pressing `i`.
+- You can retrieve a live record by pressing `r`. It will download a data record containing all declared scope values.
   - By default the recording is triggered by entering `power mode` (by pressing `p`).
   - Alternatively you can press `q` to trigger manually the recording at a different instant, or to reset the trigger
-- Plot the values by clicking `Plot recording` in `OwnTech` platformio actions.
+- Plot the values by clicking `Plot recording` in `OwnTech` PlatformIO actions.
 - Live data records can also be plotted using OwnPlot by pressing `m`. This way, the recording will be sent as an infinite loop to OwnPlot.
 
 | Control state | Comment |
@@ -86,4 +86,4 @@ angle value, then we can make a lookup table between these two variables.
 | 0      | In this state, the controller is calculating the current offset      |
 | 1      | In this state, the controller is idle          |
 | 2      | In this state, the controller is in power mode          |
-| 3      | In this state, the controller is in error mode. The error mode is entered by repetedely (repedely being defined by `error_counter`) fulfilling the following condition :  `I1_Low` going beyond the bounds `[-AC_CURRENT_LIMIT;+AC_CURRENT_LIMIT]`, `I2_Low` going beyond the bounds `[-AC_CURRENT_LIMIT;+AC_CURRENT_LIMIT]` or `I_High` exceding `DC_CURRENT_LIMIT` |
+| 3      | In this state, the controller is in error mode. The error mode is entered by repeatedly (as defined by `error_counter`) fulfilling the following condition: `I1_Low` going beyond the bounds `[-AC_CURRENT_LIMIT;+AC_CURRENT_LIMIT]`, `I2_Low` going beyond the bounds `[-AC_CURRENT_LIMIT;+AC_CURRENT_LIMIT]` or `I_High` exceeding `DC_CURRENT_LIMIT` |

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 Welcome to the OwnTech examples repository.
 
-Here you can find ready to be used example for [SPIN](https://github.com/owntech-foundation/SPIN), [TWIST](https://github.com/owntech-foundation/TWIST), and OWNVERTER.
+Here you can find ready-to-use examples for [SPIN](https://github.com/owntech-foundation/SPIN), [TWIST](https://github.com/owntech-foundation/TWIST), and OWNVERTER.
 
 # Examples for TWIST
 
 - Basic examples
     - [Open Loop PWM](TWIST/Basic/Open-Loop_PWM/README.md)
 
-- DC DC topology examples
+- DC-DC topology examples
     - [Buck voltage mode](TWIST/DC_DC/buck_voltage_mode/README.md)
     - [Buck current mode](TWIST/DC_DC/buck_current_mode/README.md)
     - [Boost voltage mode](TWIST/DC_DC/boost_voltage_mode/README.md)
     - [Interleaved Buck](TWIST/DC_DC/interleaved/README.md)
     - [Independent](TWIST/DC_DC/independent/README.md)
     - [Simple scope example](TWIST/DC_DC/scope_simple_example/README.md)
-    - [Current ripple measure in buck voltage mode](TWIST/DC_DC/current_ripple_measurement/README.md)
+    - [Current ripple measurement in buck voltage mode](TWIST/DC_DC/current_ripple_measurement/README.md)
 
 - Microgrid examples
     - [AC client server](TWIST/Microgrid/AC_client_server/README.md)
@@ -22,7 +22,7 @@ Here you can find ready to be used example for [SPIN](https://github.com/owntech
     - [DC client server](TWIST/Microgrid/DC_client_server/README.md)
     - [DC droop](TWIST/Microgrid/DC_droop/README.md)
 
-- DC AC topology examples
+- DC-AC topology examples
     - [Grid forming](TWIST/DC_AC/grid_forming/README.md)
     - [Grid following](TWIST/DC_AC/grid_following/README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 Welcome to the OwnTech examples repository.
 
-Here you can find ready to be used example for [SPIN](https://github.com/owntech-foundation/SPIN) and [TWIST](https://github.com/owntech-foundation/TWIST).
+Here you can find ready to be used example for [SPIN](https://github.com/owntech-foundation/SPIN), [TWIST](https://github.com/owntech-foundation/TWIST), and OWNVERTER.
 
 # Examples for TWIST
+
+- Basic examples
+    - [Open Loop PWM](TWIST/Basic/Open-Loop_PWM/README.md)
 
 - DC DC topology examples
     - [Buck voltage mode](TWIST/DC_DC/buck_voltage_mode/README.md)
     - [Buck current mode](TWIST/DC_DC/buck_current_mode/README.md)
     - [Boost voltage mode](TWIST/DC_DC/boost_voltage_mode/README.md)
     - [Interleaved Buck](TWIST/DC_DC/interleaved/README.md)
+    - [Independent](TWIST/DC_DC/independent/README.md)
+    - [Simple scope example](TWIST/DC_DC/scope_simple_example/README.md)
     - [Current ripple measure in buck voltage mode](TWIST/DC_DC/current_ripple_measurement/README.md)
 
 - Microgrid examples
@@ -17,15 +22,25 @@ Here you can find ready to be used example for [SPIN](https://github.com/owntech
     - [DC client server](TWIST/Microgrid/DC_client_server/README.md)
     - [DC droop](TWIST/Microgrid/DC_droop/README.md)
 
- - DC AC topology examples
+- DC AC topology examples
     - [Grid forming](TWIST/DC_AC/grid_forming/README.md)
     - [Grid following](TWIST/DC_AC/grid_following/README.md)
+
+- Communication examples
+    - [CAN Communication](TWIST/Communication/CAN/README.md)
+    - [Python Communication Protocol](TWIST/Communication/python_comm_library/README.md)
+
+# Examples for OWNVERTER
+
+- Motor control examples
+    - [BLDC motor with hall sensor](OWNVERTER/BLDC_hall_sensor/README.md)
+    - [Motor control using FOC and hall sensors](OWNVERTER/FOC_hall_sensor/README.md)
 
 # Examples for SPIN
 
 - ADC use examples
-    - [Software trigerred ADC](SPIN/ADC/adc_software_trigger/README.md)
-    - [HRTIM trigerred ADC](SPIN/ADC/adc_hrtim_trigger/README.md)
+    - [Software triggered ADC](SPIN/ADC/adc_software_trigger/README.md)
+    - [HRTIM triggered ADC](SPIN/ADC/adc_hrtim_trigger/README.md)
 
 - DAC use examples
     - [Signal generation](SPIN/DAC/signal_generation/README.md)
@@ -34,6 +49,7 @@ Here you can find ready to be used example for [SPIN](https://github.com/owntech
     - [Blinky](SPIN/LED/blinky/README.md)
 
 - PWM use examples
+    - [PWM burst mode control](SPIN/PWM/burst_mode/README.md)
     - [PWM duty cycle control](SPIN/PWM/duty_cycle_setting/README.md)
     - [PWM phase shift control](SPIN/PWM/phase_shift/README.md)
     - [Multiple PWM operation](SPIN/PWM/multiple_pwm/README.md)

--- a/SPIN/ADC/adc_hrtim_trigger/README.md
+++ b/SPIN/ADC/adc_hrtim_trigger/README.md
@@ -1,19 +1,19 @@
 # Triggering measure from ADC via HRTIM trigger
 
-An ADC, or Analog-to-Digital Converter, is a crucial component in modern electronics that converts continuous analog signals into discrete digital data. In simpler terms, it takes real-world phenomena, like sound or temperature, and turns them into numbers that a computer can understand and process. This conversion is essential for various applications, in power electronics it allows us to get real-time measures from the circuit like voltage and current. 
+An ADC, or Analog-to-Digital Converter, is a crucial component in modern electronics that converts continuous analog signals into discrete digital data. In simpler terms, it takes real-world phenomena, like sound or temperature, and turns them into numbers that a computer can understand and process. This conversion is essential for various applications, in power electronics it allows us to get real-time measurements from the circuit like voltage and current. 
 
-The spin uses the stm32G4 MCU, which has a high resolution timer (HRTIM) which can produce high resolution PWM. This example will show you how to use the HRTIM in order to trigger the measures. 
+The SPIN uses the STM32G4 MCU, which has a high-resolution timer (HRTIM) which can produce high-resolution PWM. This example will show you how to use the HRTIM in order to trigger the measurements. 
 
 ## Hardware setup and requirements
 
 ![Schematic](Image/schema.png)
 *figure 1*
 
-You will need : 
+You will need: 
 
 - 1 SPIN
-- A usb-c cable to supply power to the spin, and also upload the code from computer
-- A signal generator to create a waveform to measure it from ADC, it can be sinewave, triangle wave...etc. This signal must between **0V and 2.048V**
+- A USB-C cable to supply power to the SPIN, and also upload the code from a computer
+- A signal generator to create a waveform to measure it from the ADC, it can be a sine wave, triangle wave...etc. This signal must be between **0 V and 2.048 V**
 
 There is a total of 8 possible pins from where you can get synchronous analog measurements :
 
@@ -33,14 +33,14 @@ In this example we connect the signal generator to pin `35`, and a `GND` pin.
 
 ## Software setup 
 
-The HRTIM has 6 different timer (A,B,C,D,E,F) but you can choose up to two of them to trigger the measures. In this example we'll show you how you can use one of them **the timer A**.
+The HRTIM has 6 different timers (A, B, C, D, E, F) but you can choose up to two of them to trigger the measurements. In this example we'll show you how you can use one of them: **timer A**.
 
-On the picture below, you can see the waveform of the timer A pwm, the carrier, the duty cycle and the colored zone represents the timing where the measures is triggered. 
+In the picture below, you can see the waveform of the timer A PWM, the carrier, the duty cycle and the colored zone represents the timing where the measurement is triggered. 
 
 ![trigger_waveform](Image/Hrtim_trigger.png)
 *figure 2*
 
-The measure is triggered with the same frequency as the switching frequency, the measure is done around the trough of the carrier on the positive slope. We will explain here which functions to call to setup the ADC trigger. 
+The measurement is triggered with the same frequency as the switching frequency; the measurement is done around the trough of the carrier on the positive slope. We will explain here which functions to call to set up the ADC trigger. 
 
 First of all, we start by initializing the PWMA : 
 
@@ -52,7 +52,7 @@ First of all, we start by initializing the PWMA :
 
     spin.pwm.initUnit(PWMA); // timer initialization
 ```
-The function `setAdcEdgeTrigger` allows us to choose where we want to trigger the measures : on the positive slope `EdgeTrigger_up` of the carrier like in fig.2, or the negative slope `EdgeTrigger_down` of the carrier.
+The function `setAdcEdgeTrigger` allows us to choose where we want to trigger the measurements: on the positive slope `EdgeTrigger_up` of the carrier like in fig.2, or the negative slope `EdgeTrigger_down` of the carrier.
 
 After the initialization of the PWM, we can link it to a trigger : 
 
@@ -62,21 +62,21 @@ After the initialization of the PWM, we can link it to a trigger :
     spin.pwm.enableAdcTrigger(PWMA); // enable the trigger
 ```
 We are linking PWMA to a trigger, here `ADC_2`.  
-There is two ADCs that support synchronous data acquisition : `ADC_1` and `ADC_2`.
+There are two ADCs that support synchronous data acquisition: `ADC_1` and `ADC_2`.
 
-`setAdcTriggerInstant` will set the moment when we trigger a measure with a parameter between 0 (corresponding to the trough of the carrier)and 1 (corresponding to the crest of the carrier). Here we took 0.06, so we'll get the data around the trough of the carrier (as we have seen on fig.2)
+`setAdcTriggerInstant` will set the moment when we trigger a measurement with a parameter between 0 (corresponding to the trough of the carrier) and 1 (corresponding to the crest of the carrier). Here we took 0.06, so we'll get the data around the trough of the carrier (as we have seen on fig.2)
 
 And finally, we set the `ADC2` to be triggered by the PWM `TRIG_PWM`.
 
 ```cpp
     spin.adc.configureTriggerSource(ADC_2, TRIG_PWM); // ADC 2 configured to be triggered by the PWM
 ```
-We use the 5th channel of the adc, which is the gpio `35` on the spin (also numbered as C4). To enable the acquisition from this pin, we use the function `enableAcquisition`: 
+We use the 5th channel of the ADC, which is the GPIO `35` on the SPIN (also numbered as C4). To enable the acquisition from this pin, we use the function `enableAcquisition`: 
 
 ```cpp
     spin.data.enableAcquisition(35, ADC_2); // Enable acquisition for ADC2, for channel 5 (localized in GPIO C4 / pin number 35)
 ```
-When are now set, we must be sure that there is a critical task defined and active, and make sure that `PWMA` is active because it is now the ADC trigger source.
+When everything is now set, we must be sure that there is a critical task defined and active, and make sure that `PWMA` is active because it is now the ADC trigger source.
 
 ```cpp
     spin.pwm.startDualOutput(PWMA);
@@ -88,7 +88,7 @@ You can also use `ADC_1` to get a second independent trigger event, for instance
 we can bind `PWMC`to `ADC_1`.
 Below, we reproduce the same step but by using the `ADC1` channel 2 localized on pin `30` (PA1).
 
-start PWMC :
+Start PWMC:
 
 ```cpp
     spin.pwm.setFrequency(200000); // Set frequency of pwm
@@ -98,14 +98,14 @@ start PWMC :
 
     spin.pwm.initUnit(PWMC); // timer initialization
 ```
-link `ADC_1` to `PWMC` : 
+Link `ADC_1` to `PWMC`: 
 
 ```cpp
     spin.pwm.setAdcTrigger(PWMC, ADC_1); // PWMA is linked to ADCTRIG_1
     spin.pwm.setAdcTriggerInstant(PWMC, 0.06); // set the trigger instant
     spin.pwm.enableAdcTrigger(PWMC); // enable the trigger
 ```
-then set `ADC1` channel 2 to be triggered by the PWM : 
+Then set `ADC1` channel 2 to be triggered by the PWM: 
 
 ```cpp
     spin.adc.configureTriggerSource(ADC_1, TRIG_PWM); // ADC 1 configured to be triggered by the PWM
@@ -114,6 +114,6 @@ then set `ADC1` channel 2 to be triggered by the PWM :
 
 ## Expected results
 
-The analog value measured from the adc is stored inside the variable `adc_value`, which is printed in the serial monitor every 100ms you can then watch the measured on [ownplot](https://github.com/owntech-foundation/OwnPlot). 
+The analog value measured from the ADC is stored inside the variable `adc_value`, which is printed in the serial monitor every 100 ms. You can then watch the measurements on [OwnPlot](https://github.com/owntech-foundation/OwnPlot). 
 
-If everything went correctly, you should observe the same waveform on ownplot that you generate via the signal generator. 
+If everything went correctly, you should observe the same waveform on OwnPlot that you generate via the signal generator. 

--- a/SPIN/ADC/adc_software_trigger/README.md
+++ b/SPIN/ADC/adc_software_trigger/README.md
@@ -1,20 +1,20 @@
 # Triggering measure from ADC via software trigger
 
-An ADC, or Analog-to-Digital Converter, is a crucial component in modern electronics that converts continuous analog signals into discrete digital data. In simpler terms, it takes real-world phenomena, like sound or temperature, and turns them into numbers that a computer can understand and process. This conversion is essential for various applications, in power electronics it allows us to get real-time measures from the circuit like voltage and current. 
+An ADC, or Analog-to-Digital Converter, is a crucial component in modern electronics that converts continuous analog signals into discrete digital data. In simpler terms, it takes real-world phenomena, like sound or temperature, and turns them into numbers that a computer can understand and process. This conversion is essential for various applications, in power electronics it allows us to get real-time measurements from the circuit like voltage and current. 
 
-This example will show you how to get measures from the ADC by calling a function that will trigger the measures : this is what we call **a software trigger**.
+This example will show you how to get measurements from the ADC by calling a function that will trigger the measurements: this is what we call **a software trigger**.
 
 ## Hardware setup and requirements
 
 ![Schematic](Image/schema.png)
 
-You will need : 
+You will need: 
 
-- 1 spin
-- A usb-c cable to supply power to the spin, and also upload the code from computer
-- A signal generator to create a waveform to measure it from ADC, it can be sinewave, triangle wave...etc. This signal must between **0V and 2.048V**
+- 1 SPIN
+- A USB-C cable to supply power to the SPIN, and also upload the code from a computer
+- A signal generator to create a waveform to measure it from the ADC, it can be a sine wave, triangle wave...etc. This signal must be between **0 V and 2.048 V**
 
-Connect the signal generator to pin C4, and gnd. 
+Connect the signal generator to pin C4, and GND. 
 
 ## Software setup 
 
@@ -23,19 +23,19 @@ The ADC 2 is used here, it is initialized like this :
 ```cpp
     spin.adc.configureTriggerSource(2, software); // ADC 2 configured in software mode
 ```
-We use the 5th channel of the adc, which is the gpio C4 on the spin (also numbered as pin 35). To enable the acquisition from this pin, we use the function `enableAcquisition`: 
+We use the 5th channel of the ADC, which is the GPIO C4 on the SPIN (also numbered as pin 35). To enable the acquisition from this pin, we use the function `enableAcquisition`: 
 
 ```cpp
 data.enableAcquisition(2, 35) // Enable acquisition for ADC2, for channel 5 (localized in GPIO C4 / pin number 35)
 ```
-When we want to retrieve measures from ADC2 all we need to do is trigger ADC2 and retrieve measured value in GPIO C4 / pin number 35 :
+When we want to retrieve measurements from ADC2 all we need to do is trigger ADC2 and retrieve the measured value in GPIO C4 / pin number 35:
 
 ```cpp
    spin.data.triggerAcquisition(2);
     adc_value =spin.data.getLatestValue(2, 35);
 ```
 
-There is a total of 8 possible pin from where you can get analog measures :
+There is a total of 8 possible pins from where you can get analog measurements:
 
 | GPIO | PIN number | ADC and channels                |
 |------|------------|---------------------------------|
@@ -48,10 +48,10 @@ There is a total of 8 possible pin from where you can get analog measures :
 | PC0  | 24         | ADC1 channel 6 / ADC2 channel 6 |
 | PB15 | 6          | ADC4 channel 5                  |
 
-You can configure any of the above ADC with same steps.
+You can configure any of the above ADCs with the same steps.
 
-## Expetected results
+## Expected results
 
-The analog value measured from the adc is stored inside the variable `adc_value`, which is printed in the serial monitor every 100ms you can then watch the measured on [ownplot](https://github.com/owntech-foundation/OwnPlot). 
+The analog value measured from the ADC is stored inside the variable `adc_value`, which is printed in the serial monitor every 100 ms. You can then watch the measurements on [OwnPlot](https://github.com/owntech-foundation/OwnPlot). 
 
-If everything went correctly, you should observe the same waveform on ownplot that you generate via the signal generator. 
+If everything went correctly, you should observe the same waveform on OwnPlot that you generate via the signal generator. 

--- a/SPIN/DAC/signal_generation/README.md
+++ b/SPIN/DAC/signal_generation/README.md
@@ -7,13 +7,13 @@ A DAC, or Digital-to-Analog Converter, converts digital signals into correspondi
 ![Schematic](Image/schema.png)
 *figure 1*
 
-You will need : 
+You will need: 
 
-- 1 spin
-- A usb-c cable to supply power to the spin, and also upload the code from computer
+- 1 SPIN
+- A USB-C cable to supply power to the SPIN, and also upload the code from a computer
 - An oscilloscope to watch the DAC output
 
-Connect the oscilloscope to gpio PA6 (the DAC output).
+Connect the oscilloscope to GPIO PA6 (the DAC output).
 
 ## Software setup 
 
@@ -26,16 +26,16 @@ We start by initializing the DAC :
     spin.dac.setConstValue(2, 1, 0); // Setting DAC 2 channel 1 to 0
 ```
 
-The function `setConstValue` will convert numerical value (from 0 to 4096) to a voltage (between 0 and 2.048) with the DAC. 
+The function `setConstValue` will convert a numerical value (from 0 to 4096) to a voltage (between 0 and 2.048) with the DAC. 
 
-In the background task (called every 100ms), is increasing the value send to the DAC : 
+In the background task (called every 100 ms), the code increases the value sent to the DAC: 
 
 ```cpp
     dac_value = (dac_value + 100)%4096;
     spin.dac.setConstValue(2, 1, dac_value);
 ```
 
-You can also reproduce the same step to use DAC1 channel 1 localized in gpio PA4.
+You can also reproduce the same step to use DAC1 channel 1 localized in GPIO PA4.
 
 
 ## Expected result

--- a/SPIN/LED/blinky/README.md
+++ b/SPIN/LED/blinky/README.md
@@ -1,20 +1,20 @@
-# Blinking a led
+# Blinking an LED
 
-Here is a simple example to start with SPIN : making a led blink.
+Here is a simple example to start with SPIN: making an LED blink.
 
 ## Hardware setup and requirements
 
 ![Schematic](Image/schema.png)
 *figure 1*
 
-You will need : 
+You will need: 
 
-- 1 spin
-- A usb-c cable to supply power to the spin, and also upload the code from computer
+- 1 SPIN
+- A USB-C cable to supply power to the SPIN, and also upload the code from a computer
 
 ## Software setup
 
-The led is toggled in the background task called each 1s, which means the leed will blink at the rate of 1s : 
+The LED is toggled in the background task called every 1 s, which means the LED will blink at the rate of 1 s. 
 
 ```cpp
     spin.led.toggle();
@@ -22,4 +22,4 @@ The led is toggled in the background task called each 1s, which means the leed w
 
 ## Expected result 
 
-Visual result : the led should turn on and off. 
+Visual result: the LED should turn on and off. 

--- a/SPIN/PWM/burst_mode/README.md
+++ b/SPIN/PWM/burst_mode/README.md
@@ -1,17 +1,17 @@
 # Burst mode PWM
 
-Burst mode is an Advanced PWM capability. In few words, instead of generating a continuous stream of pulses, burst mode sends groups of PWM (Pulse Width Modulation) signals at regular intervals. This method reduces energy consumption, minimizes heat generation, and is especially useful in applications like motor control, LED dimming, and power supplies.
+Burst mode is an advanced PWM capability. In a few words, instead of generating a continuous stream of pulses, burst mode sends groups of PWM (Pulse Width Modulation) signals at regular intervals. This method reduces energy consumption, minimizes heat generation, and is especially useful in applications like motor control, LED dimming, and power supplies.
 
-In power electronics, Burst mode PWM is used two reduce losses under light load conditions
-In this example we'll show you how to setup burst mode for two phase shifted H-bridges.
-It could be used to control a Dual Active Bridge (DAB) in Single Phase Shift modulation modulation under light load conditions.
+In power electronics, burst mode PWM is used to reduce losses under light load conditions.
+In this example we'll show you how to set up burst mode for two phase-shifted H-bridges.
+It could be used to control a Dual Active Bridge (DAB) in Single Phase Shift modulation under light load conditions.
 
 ## Hardware setup and requirements
 
-You will need :
+You will need:
 
-- A spin
-- A usb-c cable to supply the spin
+- A SPIN
+- A USB-C cable to supply the SPIN
 - An oscilloscope to observe PWM waveform
 
 PWMs can be observed on:
@@ -24,7 +24,7 @@ PWMs can be observed on:
 
 During initialization:
 
-- The frequency for the pwm is set to 200kHz, you are free to choose another value.
+- The frequency for the PWM is set to 200 kHz, you are free to choose another value.
 - PWMA and PWMC for the first H-bridge.
 - PWME and PWMF for the second H-bridge.
 
@@ -41,7 +41,7 @@ During initialization:
     spin.pwm.initUnit(PWMF);
 ```
 
-- All PWM are initialized in phase.
+- All PWMs are initialized in phase.
 
 ```cpp
     /* Set initial phase shifts*/
@@ -52,8 +52,8 @@ During initialization:
 
 Burst mode initialization:
 
-- Burst mode duty is set to 8. It means that PWM output will be void during 8 PWM events
-- Burst mode Period is set to 10. It means that PWM output will be off for 8 PWM event every 10 PWM events.
+- Burst mode duty is set to 8. It means that PWM output will be off during 8 PWM events.
+- Burst mode period is set to 10. It means that PWM output will be off for 8 PWM events every 10 PWM events.
 
 ```cpp
 uint8_t burst_duty = 8;
@@ -80,11 +80,11 @@ You can control the burst mode period from the serial monitor :
 - press `t` to increase the burst mode period
 - press `y` to decrease the burst mode period
 
-On the oscilloscope you should observe
+On the oscilloscope you should observe:
 
 - That PWMs are ON only **two periods out of ten**
 - That you can control the burst duty and period to change the number of active PWM periods
-- That you can control the second H-bridge (PWME and PWMF) phase shift from the first H-bridge (PWMA PWMC)
+- That you can control the second H-bridge (PWME and PWMF) phase shift from the first H-bridge (PWMA, PWMC)
 
 **NB:**
 

--- a/SPIN/PWM/duty_cycle_setting/README.md
+++ b/SPIN/PWM/duty_cycle_setting/README.md
@@ -4,24 +4,24 @@ In the context of Pulse Width Modulation (PWM), the duty cycle refers to the pro
 
 In power electronics, such as motor control, power supplies, and voltage regulation, PWM is a widely used technique for controlling the amount of power delivered to a load. The duty cycle of the PWM signal determines the average power delivered to the load. By adjusting the duty cycle, engineers can control the speed of motors, regulate voltage levels, and efficiently manage power consumption.
 
-In this example we'll see how to generate a PWM, an control the duty cycle.
+In this example we'll see how to generate a PWM, and control the duty cycle.
 
 ## Hardware setup and requirements
 
-The spin can use up to 5 different PWM : PWMA, PWMC, PWMD, PWME and PWMF. This example will detail how to work with one of them : PWMA.
+The SPIN can use up to 5 different PWMs: PWMA, PWMC, PWMD, PWME and PWMF. This example will detail how to work with one of them: PWMA.
 
 ![schema](Image/schema.png)
 *Figure 1*
 
 PWMA has two complementary channels :
 
-- PWMA1 on gpio A8
-- PWMA2 on gpio A9
+- PWMA1 on GPIO A8
+- PWMA2 on GPIO A9
 
-You will need :
+You will need:
 
-- A spin
-- A usb-c cable to supply the spin
+- A SPIN
+- A USB-C cable to supply the SPIN
 - An oscilloscope to watch PWM waveform
 
 ## Software setup
@@ -33,7 +33,7 @@ First we start by initializing the PWMA :
     spin.pwm.initUnit(PWMA); // timer initialization
 ```
 
-The frequency for the pwm is initalized to 200kHz but you are free to choose another value.
+The frequency for the PWM is initialized to 200 kHz but you are free to choose another value.
 
 The duty cycle is updated in the high-speed control task :
 
@@ -45,10 +45,10 @@ You can control the duty cycle from the serial monitor :
 - press `u` to increase the duty cycle
 - press `d` to decrease the duty cycle
 
-See [ownplot](https://github.com/owntech-foundation/OwnPlot) if you would like a better graphical interface for the serial monitor.
+See [OwnPlot](https://github.com/owntech-foundation/OwnPlot) if you would like a better graphical interface for the serial monitor.
 
 ## Expected result
 
 ![waveform](Image/waveform_PWMA.png)
 
-On the oscilloscope you should observe two complementary PWM and their evolution when you increase/decrease the duty cycle.
+On the oscilloscope you should observe two complementary PWMs and their evolution when you increase/decrease the duty cycle.

--- a/SPIN/PWM/multiple_pwm/README.md
+++ b/SPIN/PWM/multiple_pwm/README.md
@@ -1,29 +1,29 @@
 # Working with multiple PWM
 
-The spin has a total of 5 PWM channels with 2 complementary output each. In this example, we'll detail how to use each of them.
+The SPIN has a total of 5 PWM channels with 2 complementary outputs each. In this example, we'll detail how to use each of them.
 
 ## Hardware setup and requirements
 
 ![schema](Image/schema.png)
 *figure 1*
 
-You will need :
+You will need:
 
-- A spin
-- A usb-c cable to supply the spin
+- A SPIN
+- A USB-C cable to supply the SPIN
 - An oscilloscope to watch PWM waveform
 
-We can watch :
+We can watch:
 
--PWMA1 on gpio A8
--PWMC1 on gpio B12
--PWMD1 on gpio B14
--PWME1 on gpio C8
--PWMF1 on gpio C6
+- PWMA1 on GPIO A8
+- PWMC1 on GPIO B12
+- PWMD1 on GPIO B14
+- PWME1 on GPIO C8
+- PWMF1 on GPIO C6
 
 ## Software setup
 
-This example is initializing every PWM, and making a phase shift 77° (= 360/5°) as if we working in interleaved mode. See the [ phase shift ](../phase_shift/README.md) example for more details.
+This example is initializing every PWM, and making a phase shift of 72° (= 360/5) as if we were working in interleaved mode. See the [phase shift](../phase_shift/README.md) example for more details.
 
 The duty cycle is the same for both PWMA and PWMC.
 
@@ -31,10 +31,10 @@ You can control the duty cycle from the serial monitor :
 - press `u` to increase the duty cycle
 - press `d` to decrease the duty cycle
 
-See [ownplot](https://github.com/owntech-foundation/OwnPlot) if you would like a better graphical interface for the serial monitor.
+See [OwnPlot](https://github.com/owntech-foundation/OwnPlot) if you would like a better graphical interface for the serial monitor.
 
 ## Expected result
 
 ![waveform](Image/waveform_multiple_pwm.png)
 
-You should observe 5 PWM with a phaseshift of 77° between them.
+You should observe 5 PWMs with a phase shift of 72° between them.

--- a/SPIN/PWM/phase_shift/README.md
+++ b/SPIN/PWM/phase_shift/README.md
@@ -2,22 +2,22 @@
 
 Phase shift in Pulse Width Modulation (PWM) refers to the intentional offset of the timing between multiple PWM signals. This offset alters the switching instants of the signals, affecting the distribution of power delivery and minimizing ripple in power electronic systems.
 
-Phase shifting PWM is used in interleaved topology for power electronics. In this example we'll show you how setup a phase shift for a 2 leg interleaved configuration for example.
+Phase shifting PWM is used in interleaved topology for power electronics. In this example we'll show you how to set up a phase shift for a 2-leg interleaved configuration.
 
 ## Hardware setup and requirements
 
-The spin can use up to 5 different PWM : PWMA, PWMC, PWMD, PWME and PWMF. This example will detail how to work with two of them in phase shifted mode : PWMA and PWMB.
+The SPIN can use up to 5 different PWMs: PWMA, PWMC, PWMD, PWME and PWMF. This example will detail how to work with two of them in phase-shifted mode: PWMA and PWMC.
 
 ![schema](Image/schema.png)
 *Figure 1*
 
-You will need :
+You will need:
 
-- A spin
-- A usb-c cable to supply the spin
+- A SPIN
+- A USB-C cable to supply the SPIN
 - An oscilloscope to watch PWM waveform
 
-We can watch PWMA1 on gpio A8 and PWMC1 on gpio B12.
+We can watch PWMA1 on GPIO A8 and PWMC1 on GPIO B12.
 
 ## Software setup
 
@@ -36,9 +36,9 @@ We start by initializing PWMA and PWMC :
     spin.pwm.startDualOutput(PWMC); // Start PWM
 ```
 
-The frequency for the pwm is initalized to 200kHz but you are free to choose another value.
+The frequency for the PWM is initialized to 200 kHz but you are free to choose another value.
 
-PWMC is shifted of 180° from PWMA.
+PWMC is shifted by 180° from PWMA.
 
 The duty cycle is updated in the high-speed control task :
 
@@ -53,10 +53,10 @@ You can control the duty cycle from the serial monitor :
 - press `u` to increase the duty cycle
 - press `d` to decrease the duty cycle
 
-See [ownplot](https://github.com/owntech-foundation/OwnPlot) if you would like a better graphical interface for the serial monitor.
+See [OwnPlot](https://github.com/owntech-foundation/OwnPlot) if you would like a better graphical interface for the serial monitor.
 
 ## Expected result
 
 ![waveform](Image/waveform_phase_shift.png)
 
-On the oscilloscope you should observe that PWMC1 is phase shifted of 180° from PWMA1 (which means they are complementary).
+On the oscilloscope you should observe that PWMC1 is phase shifted by 180° from PWMA1 (which means they are complementary).

--- a/SPIN/TIMER/incremental_encoder/README.md
+++ b/SPIN/TIMER/incremental_encoder/README.md
@@ -2,17 +2,17 @@
 
 An incremental encoder is a device that converts mechanical motion into digital signals. It typically consists of a rotating disk with evenly spaced slots and a sensor that detects these slots as the disk turns. The sensor generates electrical pulses corresponding to the motion, which can be used to track position, speed, or direction.
 
-in this example we'll see how to use an incremental encoder with spin.
+In this example we'll see how to use an incremental encoder with SPIN.
 
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 ![schema](Image/spin_wiring_diagram.drawio)
 
-You will need :
+You will need:
 
-- A spin
-- A usb-c cable to supply the spin
+- A SPIN
+- A USB-C cable to supply the SPIN
 - A rotary incremental encoder
 - A 5V supply for your incremental encoder
 
@@ -42,6 +42,6 @@ This value is displayed in the serial monitor.
 
 ## Expected result
 
-You should see the value in the serial monitor either increasing or decresing depending on how you turning the rotary incremental encoder (clokc-wise or not).
+You should see the value in the serial monitor either increasing or decreasing depending on how you are turning the rotary incremental encoder (clockwise or not).
 
-Every turn your values should be reset to a reference value that will depend on your encoder. 
+Every turn, your values should be reset to a reference value that will depend on your encoder. 

--- a/TWIST/Basic/Open-Loop PWM/README.md
+++ b/TWIST/Basic/Open-Loop PWM/README.md
@@ -1,13 +1,13 @@
 # Open Loop PWM
 
-The goal of this basic example is to understand what is a duty cycle and how it is related to power flow. We will use our TWIST as a buck converter in an open-loop to divide our voltage by 2.
+The goal of this basic example is to understand what a duty cycle is and how it is related to power flow. We will use our TWIST as a buck converter in open loop to divide our voltage by 2.
 
-!!! warning "Are you ready to start ?"
+!!! warning "Are you ready to start?"
 
-    Before you can run this example, you must have : 
+    Before you can run this example, you must have: 
     
     - successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/) tutorial to set up your work environment
-    - successfully gone through our [first example](https://docs.owntech.org/latest/core/docs/first_example/) tutorial and download the "Open Loop PWM" example 
+    - successfully gone through our [first example](https://docs.owntech.org/latest/core/docs/first_example/) tutorial and downloaded the "Open Loop PWM" example 
 
 
 ## Background
@@ -15,9 +15,9 @@ The goal of this basic example is to understand what is a duty cycle and how it 
 
 ### What is a PWM ?
 
-PWM or Pulse-Width-Modulation is based on the idea that a periodic (repetitive) logic signal (ON/OFF or 0/1) can have its width changed over time. This is shown on the three images below, where you can see the width of the $T_{ON}$ changing from `25%` to `75%` of the total period.
+PWM, or Pulse-Width Modulation, is based on the idea that a periodic (repetitive) logic signal (ON/OFF or 0/1) can have its width changed over time. This is shown on the three images below, where you can see the width of the $T_{ON}$ changing from `25%` to `75%` of the total period.
 
-As shown in [](#fig-duty-25), the duty cycle is `25%` of the total time (`T`), is called `period`. 
+As shown in [](#fig-duty-25), the duty cycle is `25%` of the total time (`T`), which is called the period. 
 
 ![Representation of a duty cycle of 25%](Image/duty_cycle_025_light.svg#only-light){ #fig-duty-25 width=500}
 ![Representation of a duty cycle of 25%](Image/duty_cycle_025_dark.svg#only-dark){ #fig-duty-25 width=500 }
@@ -65,7 +65,7 @@ In power electronics, switching between transistors is NOT instantaneous. To avo
 
 The deadtime can be of three formats: zero, positive or negative.
 
-In zero deadtime, both PWM signal switches **simultaneouly** as shown in [] 
+In zero deadtime, both PWM signal switches **simultaneously** as shown in [] 
 
 ![No deadtime of a PWM signal](Image/no_deadtime_light.svg#only-light){ #fig-no-deadtime width=500}
 ![No deadtime of a PWM signal](Image/no_deadtime_dark.svg#only-dark){ #fig-no-deadtime width=500}
@@ -79,7 +79,7 @@ In zero deadtime, both PWM signal switches **simultaneouly** as shown in []
 The length of the deadtime in either the rising or falling edges depends on the application.   
 
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 -----------
 
 ### Circuit diagram
@@ -106,13 +106,13 @@ The wiring diagram is shown in [](#fig-wiring).
 ![The wiring diagram of this example setup (click to zoom)](Image/wiring_diagram_light.svg#only-light){ #fig-wiring width=full .on-glb}
 ![The wiring diagram of this example setup (click to zoom)](Image/wiring_diagram_dark.svg#only-dark){ #fig-wiring width=full .on-glb}
 
-Once you have wired the cables are connected your TWIST board to your computer, you can upload the example code.  
+Once you have wired the cables and connected your TWIST board to your computer, you can upload the example code.  
 
-!!! warning "Is you software ready?"
-    Before you can run this example, you must have : 
+!!! warning "Is your software ready?"
+    Before you can run this example, you must have: 
     
     - successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/) tutorial to set up your work environment
-    - successfully gone through our [first example](https://docs.owntech.org/latest/core/docs/first_example/) tutorial and download the "Open Loop PWM" example 
+    - successfully gone through our [first example](https://docs.owntech.org/latest/core/docs/first_example/) tutorial and downloaded the "Open Loop PWM" example 
 
 
 ## Main code structure
@@ -120,12 +120,12 @@ Once you have wired the cables are connected your TWIST board to your computer, 
 
 ### Code structure 
 
-Let's briefly explain the conde structure of the `main.cpp` file of this example. 
+Let's briefly explain the code structure of the `main.cpp` file of this example. 
 
 [](#fig-code-struct) shows a general representation of how the code is structured.
 
-![Oveview of the code structure (click to zoom)](Image/code_structure_light.svg#only-light){ #fig-code-struct width=500 .on-glb}
-![Oveview of the code structure (click to zoom)](Image/code_structure_dark.svg#only-dark){ #fig-code-struct width=500 .on-glb}
+![Overview of the code structure (click to zoom)](Image/code_structure_light.svg#only-light){ #fig-code-struct width=500 .on-glb}
+![Overview of the code structure (click to zoom)](Image/code_structure_dark.svg#only-dark){ #fig-code-struct width=500 .on-glb}
 
 The code structure is as follows:
 
@@ -139,8 +139,8 @@ The code structure is as follows:
 
 The firmware of the TWIST board is executed according to the diagram in [](#fig-timing-diagram).
 
-- **Communication Task** - Is awaken regularly to verify any keyboard activity
-- **Application Task** - This task is woken once its suspend is finished. By default its period if of **100 miliseconds**. 
+- **Communication Task** - Is awakened regularly to verify any keyboard activity
+- **Application Task** - This task is woken once its suspension is finished. By default its period is **100 milliseconds**. 
 - **Critical Task** - This task is driven by the HRTIM count interrupt, where it counts a number of HRTIM switching frequency periods. In this case 100us, or 20 periods of the TWIST board 200kHz switching frequency set by default.
 
 ![Timing diagram of the tasks](Image/task_diagram_light.svg#only-light){ #fig-timing-diagram width=full .on-glb}
@@ -161,7 +161,7 @@ There is no control scheme in this example. By default it is in `Open-loop`.
     - In the bottom toolbar, click on the Serial Monitor icon ![](Image/serial_monitor_button.png). Then click on the serial monitor screen. 
 
 
-This code will control `duty_cycle` so that the voltage output will vary. You can control the duty cycle through platformio serial monitor. 
+This code will control `duty_cycle` so that the voltage output will vary. You can control the duty cycle through the PlatformIO serial monitor. 
 
 When opening it for the first time, the serial monitor will give you an initialization message regarding the parameters of the ADCs as shown below.  
 
@@ -176,9 +176,9 @@ When opening it for the first time, the serial monitor will give you an initiali
     - press `d` to decrease the duty cycle by 0.05
     - press `h` to show the help menu
 
-Here's sequence when the help menu is activated with `h`, the power mode is then activated with `p`, duty cycle is raised up to `0.5` and finally the Twist converter is put in idle with the `i`. 
+Here's the sequence when the help menu is activated with `h`, the power mode is then activated with `p`, the duty cycle is raised up to `0.5` and finally the Twist converter is put in idle with the `i`. 
 
-![Serial monitor output of the sequency above](Image/buck1_serial.png)
+![Serial monitor output of the sequence above](Image/buck1_serial.png)
 
 
 You can measure the DC output voltage thanks to an oscilloscope or a multimeter.

--- a/TWIST/Communication/CAN/README.md
+++ b/TWIST/Communication/CAN/README.md
@@ -3,24 +3,24 @@ This example shows how to use the CAN interface present on both TWIST
 and OWNVERTER power shields.
 
 # CAN protocol
-Data is using Thingset protocol. Full specification can be accessed here :
-[thingset](thingset.io)
+Data uses the Thingset protocol. The full specification can be accessed here:
+[thingset](https://thingset.io)
 
 # Using CAN on OwnTech boards
-CAN related functions can be used by typing
+CAN-related functions can be used by typing
 `communication.can.` in your main.cpp file.
-Autocompletion will give you insights of available API functions.
+Autocompletion will give you insights into available API functions.
 
 Currently the API supports two modes :
 - Sending reports containing data over CAN, in this example live measurements
 - Sending control commands over CAN
 
-For now two simple commands are supported:
+For now, two simple commands are supported:
 - Sending a floating point reference.
-- Sending a start - stop boolean.
+- Sending a start-stop boolean.
 
 # App.conf
-`app.conf` file permits to simply add complex modules. In this example, CAN
+The `app.conf` file allows you to simply add complex modules. In this example, CAN
 communication is enabled by setting
 
 ```CONFIG_OWNTECH_COMMUNICATION_ENABLE_CAN=y```
@@ -34,7 +34,7 @@ Relevant configs are found in `Modules->thingset-sdk->Thingset SDK->CAN interfac
 
 # user_data_objects.h
 This new file is a manifest that permits the user to define custom values that
-should be broadcasted over CAN.
+should be broadcast over CAN.
 
 Follow the syntax provided with the default measurements to add yours.
 We also strongly suggest reading the [Thingset protocol specification](https://thingset.io/spec/v0.6/introduction/abstract.html).
@@ -46,11 +46,11 @@ Make sure you have a suitable hardware adapter to link `RJ45` terminals of the
 OwnTech board to the `D Sub - 15` terminal of the adapter. `GND` `CAN-RX` and
 `CAN-TX` are required to be able to receive and send messages.
 
-PEAK CAN to USB adapter is supported. It works natively on linux.
+PEAK CAN-to-USB adapter is supported. It works natively on Linux.
 The following configuration should also work for other CAN dongle adapters,
 granted that you've installed any required driver.
 
-To visualize CAN data stream
+To visualize the CAN data stream
 
 1. Open a terminal
 2. Set dongle parameters ``` sudo ip link set can0 type can bitrate 500000 restart-ms 500 ```
@@ -59,7 +59,7 @@ To visualize CAN data stream
 
 # Using Download Firmware Upgrade over CAN
 
-Now that the CAN interface is running, you can take benefits of it to download
+Now that the CAN interface is running, you can take advantage of it to download
 new firmware through CAN as well.
 
 For that :
@@ -68,6 +68,5 @@ For that :
 ``` sudo ip link set can0 type can bitrate 500000 restart-ms 500 ```
 2. Enable the CAN interface ``` sudo ip link set can0 up ```
 3. Build your firmware as you would do normally.
-4. Once build execute the following script from a terminal
+4. Once built execute the following script from a terminal
 ``` ~/.platformio/packages/framework-zephyr/_pio/thingset-zephyr-sdk/scripts/thingset-dfu-can.py -t 1 .pio/build/USB/firmware.mcuboot.bin ```
-

--- a/TWIST/Communication/python_comm_library/README.md
+++ b/TWIST/Communication/python_comm_library/README.md
@@ -1,14 +1,14 @@
 # Python Communication Protocol
 
-This example uses the python communication protocol library to drive a Twist 1.4.1 board in Buck mode.
+This example uses the Python communication protocol library to drive a Twist 1.4.1 board in buck mode.
 
-The script will send data to the board, retrive the measurements and show them on a graph.
+The script will send data to the board, retrieve the measurements and show them on a graph.
 
 !!! danger Advanced example
      This is an advanced example. Make sure you are comfortable with using the [voltage mode](https://docs.owntech.org/examples/TWIST/DC_DC/buck_voltage_mode/) **before** doing this emulator.
 
 
-## Hardware wiring and requirement
+## Hardware wiring and requirements
 
 The wiring of the system is given by the image below:
 - The power converter is connected in `buck` mode with a source and a load.
@@ -17,17 +17,17 @@ The wiring of the system is given by the image below:
 
 ![Communication setup](Image/Comm_system.png)
 
-You will need :
+You will need:
 - 1 TWIST (it works with the OWNVERTER too!)
-- 1 dc power supply (20-60V)
+- 1 DC power supply (20-60 V)
 - 1 power load
 - 1 PC
 
-!!! warning Make sure you read this readme all the way to the end
+!!! warning Make sure you read this README all the way to the end
 
 ## Embedded Firmware setup
 
-We import the `communication_library` in `platformio.ini` via the line. Be careful to include the `#power_tuesday` at the end, since it will get the right version of the protocol :
+We import the `communication_library` in `platformio.ini` via the line. Be careful to include the `#power_tuesday` at the end, since it will get the right version of the protocol:
 
 ```ini
 lib_deps=
@@ -36,7 +36,7 @@ lib_deps=
 
 ## Embedded Firmware explanation
 
-The emebedded firmware will configure the `TWIST` or `OWNVERTER` board to be able to communicate with your computer via python. 
+The embedded firmware will configure the `TWIST` or `OWNVERTER` board to be able to communicate with your computer via Python. 
 
 The software deploys a communication system with three modes:
 
@@ -53,9 +53,9 @@ The software deploys a communication system with three modes:
    - :zap: in the critical_task: starts the power flow, controls the power flow with a PID
 
 !!! Tip How the system works
-    Characters are sent via the Serial port to the `SPIN` board.
-    It parses these characters and decides which value to put in which variables that describes the power converter.
-    For more details, please checkout the [communication protocol library readme](https://github.com/owntech-foundation/python_twist_comm_protocol)
+    Characters are sent via the serial port to the `SPIN` board.
+    It parses these characters and decides which value to put in which variables that describe the power converter.
+    For more details, please check out the [communication protocol library README](https://github.com/owntech-foundation/python_twist_comm_protocol)
 
 
 ## Python script
@@ -87,7 +87,7 @@ It will send a triangular waveform to the board and plot it in real-time.
       }
     ```
 
-    The handler will decide what the message is about and then update the appropriate structure of the communicaiton protocol that handles the information.
+    The handler will decide what the message is about and then update the appropriate structure of the communication protocol that handles the information.
 
     Which activates the power leg `LEG1`.
 
@@ -99,7 +99,7 @@ This code was tested using the following hardware setup:
 ![Emulator setup](Image/HIL_system_real.png)
 
 On the photo:
-  - A computer running the `comm_script.py` python script.
+  - A computer running the `comm_script.py` Python script.
   - A Twist board connected in Buck mode.
   - A voltage source.
   - A resistor connected to `LEG1` and `LEG2`
@@ -110,8 +110,8 @@ On the photo:
 Before running the code
 
 !!! warning Make sure you have:
-    - `python` installed in your computer.
+    - `python` installed on your computer.
     - that you follow the [firmware setup instructions](#embedded-firmware-setup) and have the appropriate libraries listed in `platformio.ini`.
     - flash the `main.cpp` in your Twist board
 
-Once all of the above are ok, you can then run the `comm_script.py` script with your python3.
+Once all of the above are OK, you can then run the `comm_script.py` script with your Python 3.

--- a/TWIST/DC_AC/grid_following/README.md
+++ b/TWIST/DC_AC/grid_following/README.md
@@ -1,6 +1,6 @@
-# Ac current source follower
+# AC current source follower
 
-In this example you need to have a first Twist with the [Grid Forming](../grid_forming/README.md) example.
+In this example you need to have a first TWIST with the [Grid Forming](../grid_forming/README.md) example.
 
 <div style="text-align:center"><img src="Image/schema_grid_following.png" alt="Schematic p2p" width="600"></div>
 
@@ -10,15 +10,15 @@ The parameters are:
 * $R_{LOAD} = 15 \Omega$.
 
 In the second Twist we use a software phase locked loop ( _"PLL"_ ).
-By this way we are synchronised with the grid voltage and we can then inject current
+In this way we are synchronized with the grid voltage and we can then inject current
 with a power factor of one. The current is regulated using a proportional resonant (_"PR"_)
 regulator.
 
-## Software overview 
+## Software overview
 ### Import a library
 
-the _"pll"_ and _"pr"_ are provided by the OwnTech control library which must be included 
-in the file `platfomio.ini`.
+The _"PLL"_ and _"PR"_ are provided by the OwnTech control library which must be included 
+in the file `platformio.ini`.
 
 ```
 lib_deps=
@@ -36,7 +36,7 @@ prop_res.init(params);
 The parameters are defined with these values:
 
 ```cpp
-static Pr prop_res; // controller instanciation. 
+static Pr prop_res; // controller instantiation. 
 static float32_t Kp = 0.2F;
 static float32_t Kr = 3000.0F;
 static float32_t Ts = control_task_period * 1.0e-6F;
@@ -62,7 +62,7 @@ and use it:
 pll_datas = pll.calculateWithReturn(V1_low_value - V2_low_value);
 ```
 
-The calculation return a structure with 3 fields:
+The calculation returns a structure with 3 fields:
 
 1. the pulsation `w` in [rad/s]
 2. the angle `angle` in [rad]
@@ -82,22 +82,21 @@ And then: $U_{12} = (2.\alpha - 1).U_{DC}$
 
 $\alpha = \dfrac{U_{12}}{2.U_{DC}}  + 0.5$
 
-## Retrieve recorded datas
+## Retrieve recorded data
 
-After stop i.e. in IDLE mode you can retrieve some data by pressing 'r'. It calls a
-function `dump_scope_datas()` which send to the console variables recorded during
+After stopping, i.e. in IDLE mode, you can retrieve some data by pressing `r`. It calls a
+function `dump_scope_datas()` which sends to the console variables recorded during
 the power flow phase.
 
-But before running, you have to add one line in the file `platfomio.ini`
+But before running, you have to add one line in the file `platformio.ini`
 
 ```ini
 monitor_filters = recorded_datas
 ```
 
-And you have to put the python script `filter_datas_recorded.py` in a `monitor` directory
-which must be in you parent project directory. Then the script should capture the
-console stream to put it in a txt file named `year-month-day_hour_minutes_secondes_record.txt`.
+And you have to put the Python script `filter_datas_recorded.py` in a `monitor` directory
+which must be in your parent project directory. Then the script should capture the
+console stream to put it in a TXT file named `year-month-day_hour_minutes_seconds_record.txt`.
 
-These files can be plotted using the `plot_data.py` python script if you have the
+These files can be plotted using the `plot_data.py` Python script if you have the
 `matplotlib` and `numpy` modules installed.
-

--- a/TWIST/DC_AC/grid_forming/README.md
+++ b/TWIST/DC_AC/grid_forming/README.md
@@ -1,6 +1,6 @@
-# Ac Voltage Source
+# AC Voltage Source
 
-In this example we build an AC voltage source using a Twist and supply a resistor.
+In this example we build an AC voltage source using a TWIST and supply a resistor.
 
 <div style="text-align:center"><img src="Image/grid_forming.png" alt="Schematic p2p" width="600"></div>
 
@@ -17,7 +17,7 @@ This example depends on two libraries:
 1. control_library
 2. ScopeMimicry
 
-To use them, you have to add the following lines in platformio.ini file:
+To use them, you have to add the following lines in the `platformio.ini` file:
 ```
 lib_deps=
     control_library = https://github.com/owntech-foundation/control_library.git
@@ -39,7 +39,7 @@ prop_res.init(params);
 The parameters are defined with these values:
 
 ```cpp
-static Pr prop_res; // controller instanciation. 
+static Pr prop_res; // controller instantiation. 
 static float32_t Kp = 0.02F;
 static float32_t Kr = 4000.0F;
 static float32_t Ts = control_task_period * 1.0e-6F;
@@ -47,9 +47,9 @@ static float32_t w0 = 2.0 * PI * 50.0;   // pulsation
 static float32_t Udc = 40.0F;
 ```
 
-## 3. Run the example.
+## Run the example
 
-!!! tip Finger in the trigger    
+!!! tip Finger on the trigger
 
     To capture the current ripple you have to follow these steps:
     - press the **`p`** key to go in `POWER_MODE`
@@ -59,10 +59,10 @@ static float32_t Udc = 40.0F;
 
 
 After these steps you should see in your directory a new folder called `Data_records` appear.
-Within it you will find three files with the following naming convention : 
+Within it you will find three files with the following naming convention: 
 
 - `Year-month-day-hour-minute-second.txt` - a raw data file
-- `Year-month-day-hour-minute-second.csv` - a post-treated csv file
+- `Year-month-day-hour-minute-second.csv` - a post-processed CSV file
 - `Year-month-day-hour-minute-second.png` - an automatically generated png file
 
 As an example here are two acquisitions:
@@ -70,15 +70,15 @@ As an example here are two acquisitions:
 ![data records](Image/data_records.png)
 
 In the code there's some parameters you can change:
-- `num_trig_ration_point`: it sets the number of trig_ratio value will be sweep
+- `num_trig_ratio_point`: it sets the number of trig_ratio values that will be swept
   between `begin_trig_ratio` and `end_trig_ratio`
 - `begin_trig_ratio` : beginning value of the sweep.
 - `end_trig_ratio`: end value of the sweep.
 
 
-### To view some variables.
-After stop i.e. in IDLE mode you can retrieve some data by pressing 'r'. It calls a
-function `dump_scope_datas()` which send to the console variables recorded during
+### To view some variables
+After stopping, i.e. in IDLE mode, you can retrieve some data by pressing `r`. It calls a
+function `dump_scope_datas()` which sends to the console variables recorded during
 the power flow phase.
 
 
@@ -95,4 +95,3 @@ We change at the same time $\alpha_1$ and $\alpha_2$, then we have : $\alpha_1 =
 And then: $U_{12} = (2.\alpha - 1).U_{DC}$
 
 $\alpha = \dfrac{U_{12}}{2.U_{DC}}  + 0.5$
-

--- a/TWIST/DC_DC/boost_voltage_mode/README.md
+++ b/TWIST/DC_DC/boost_voltage_mode/README.md
@@ -1,11 +1,11 @@
 # Boost with PID controlled output voltage
 
-A voltage mode boost converter regulates voltage by comparing the output voltage to a reference voltage. It adjusts the duty cycle of its switching signal to keep the output voltage stable. This type of converter efficiently steps up voltage levels, making it useful in various electronic devices such as converting photovoltaic panel voltage.
+A voltage mode boost converter regulates voltage by comparing the output voltage to a reference voltage. It adjusts the duty cycle of its switching signal to keep the output voltage stable. This type of converter efficiently steps up voltage levels, making it useful in various electronic devices such as for converting photovoltaic panel voltage.
 
 This example will implement a voltage mode boost converter to control the output.
 
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 The circuit diagram of the board is shown in the image below.
 
@@ -18,10 +18,10 @@ The power flows from `V1Low` to `V_high`. The wiring diagram is shown in the fig
 ![wiring diagram](Image/wiring_diagram.png)
 
 
-You will need :
+You will need:
 - 1 TWIST
-- A dc power supply (**max 10V**)
-- A resistor (or a dc electronic load)
+- A DC power supply (**max 10 V**)
+- A resistor (or a DC electronic load)
 
 ## Software setup and structure
 
@@ -38,7 +38,7 @@ The code structure is as follows:
 - **Setup Routine** - calls functions that set the hardware and software
 - **Communication Task** - Handles the keyboard communication and decides which `MODE` is activated
 - **Application Task** - Handles the `MODE`, activates the LED and prints data on the serial port 
-- **Critical Task** - Handles the `MODE` sets power ON/OFF and track the `V_high` variable with a `PID`
+- **Critical Task** - Handles the `MODE`, sets power ON/OFF and tracks the `V_high` variable with a `PID`
 
 The tasks are executed following the diagram below. 
 
@@ -46,15 +46,15 @@ The tasks are executed following the diagram below.
 ![Timing diagram](Image/timing_diagram.png)
 
 
-- **Communication Task** - Is waken regularly to verify any keyboard activity
-- **Application Task** - This task is woken once its suspend is finished 
+- **Communication Task** - Is awakened regularly to verify any keyboard activity
+- **Application Task** - This task is woken once its suspension is finished 
 - **Critical Task** - This task is driven by the HRTIM count interrupt, where it counts a number of HRTIM switching frequency periods. In this case 100us, or 20 periods of the TWIST board 200kHz switching frequency set by default.
 
 
 
 #### Control scheme
 
-The control library is imported in platformio.ini via the line :
+The control library is imported in `platformio.ini` via the line:
 
 ```
 lib_deps=
@@ -74,13 +74,12 @@ The control diagram of the `PID` is shown in the figure below.
 
 ## Expected result
 
-This code will control the output voltage to have 15V, you can control the output voltage with the serial monitor :
+This code will control the output voltage to have 15 V. You can control the output voltage with the serial monitor:
 
-- press `u` to increase the voltage reference by 0.5V
-- press `d` to decrease the voltage reference by 0.5V
+- press `u` to increase the voltage reference by 0.5 V
+- press `d` to decrease the voltage reference by 0.5 V
 
 The following plot shows the expected result. Here the voltage reference was modified and `V_High` can be seen to follow it. 
 Both currents are negative, as the current measurement `I_High` is in the `load` convention and the current measurement `I1_low` is in `source` convention.  
 
 ![Expected result](Image/result_plot.png)
-

--- a/TWIST/DC_DC/buck_current_mode/README.md
+++ b/TWIST/DC_DC/buck_current_mode/README.md
@@ -9,13 +9,13 @@ Peak current control mode is a technique used in DC-DC converters to regulate th
 !!! warning The Buck stops here 
     Currently current mode is only supported for **buck configuration**.
 
-!!! warning "Are you ready to start ?"
+!!! warning "Are you ready to start?"
     Before you can run this example:
     - you **must** have successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/).
     - ideally, you should have successfully gone through our [Voltage Mode Example](https://docs.owntech.org/latest/examples/TWIST/DC_DC/buck_voltage_mode/)  
 
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 The circuit diagram of the board is shown in the image below.
 
@@ -27,9 +27,9 @@ The power flows from `VHigh` to `VLow`. The wiring diagram is shown in the figur
 ![wiring diagram](Image/wiring_diagram.png)
 
 
-!!! warning Hardwares pre-requisites
+!!! warning Hardware pre-requisites
     You will need:
-    - 1 twist
+    - 1 TWIST
     - A DC power supply
     - A resistor (or a DC electronic load)
 
@@ -62,8 +62,8 @@ The tasks are executed following the diagram below.
 ![Timing diagram](Image/timing_diagram.png)
 
 
-- **Communication Task** - Is awaken regularly to verify any keyboard activity
-- **Application Task** - This task is woken once its suspend is finished 
+- **Communication Task** - Is awakened regularly to verify any keyboard activity
+- **Application Task** - This task is woken once its suspension is finished 
 - **Critical Task** - This task is driven by the HRTIM count interrupt, where it counts a number of HRTIM switching frequency periods. In this case 100us, or 20 periods of the TWIST board 200kHz switching frequency set by default.
 
 
@@ -81,25 +81,25 @@ The voltage measurement `V1_low_value` and the `voltage_reference` are given to 
 When the current measurement is higher than the comparator reference, it will reset the HRTIM, bringing its output from 1 to 0.  
 
 !!! note Source material
-    We recommend you check [stm32 application note](https://www.st.com/resource/en/application_note/an5497-buck-current-mode-with-the-bg474edpow1-discovery-kit-stmicroelectronics.pdf) for more informations about current mode.
+    We recommend you check the [STM32 application note](https://www.st.com/resource/en/application_note/an5497-buck-current-mode-with-the-bg474edpow1-discovery-kit-stmicroelectronics.pdf) for more information about current mode.
 
 
 ## Expected result
 
-This code will control the output voltage to have 15V, you can control the output voltage with platformio serial monitor. The image below shows your a snippet of the window and the button to press.
+This code will control the output voltage to have 15 V. You can control the output voltage with the PlatformIO serial monitor. The image below shows you a snippet of the window and the button to press.
 
 ![serial monitor button](Image/serial_monitor_button.png)
 
-When opening it for the first time, the serial monitor will give you an initialization message regarding the parameteres of the ADCs as shown below.  
+When opening it for the first time, the serial monitor will give you an initialization message regarding the parameters of the ADCs as shown below.  
 
 ![serial monitor initialization](Image/serial_monitor_initialization.png)
 
-!!! tip Commands keys
+!!! tip Command keys
     - press `u` to increase the voltage
     - press `d` to decrease the voltage
     - press `h` to show the help menu
 
-Here's sequence where: 
+Here's the sequence where: 
 - the help menu is activated with `h`, 
 - the power mode is then activated with `p` 
 - the voltage reference is raised from `15 V` to `16 V`
@@ -119,17 +119,16 @@ Here's sequence where:
     - `V2` is the voltage in `LEG2` of the `LOW` side
     - `IpeakRef` is the current reference calculated and given to both `LEG1` and `LEG2` of the `LOW` side
 
-    For instance when you reveive this: 
+    For instance, when you receive this: 
 
     ```c 
     16.000:16.194:16.233:1.500:
     ```
 
-    It means that `voltage_ref = 16 V`, `V1 = 16.194 V`, `V2 = 16.233 V` and `peak_reference = 1.5 V`. 
+    It means that `voltage_ref = 16 V`, `V1 = 16.194 V`, `V2 = 16.233 V` and `peak_reference = 1.5 A`. 
 
-    If you plot your data with a python code, you should get something like the image below. You can see the voltages follow the reference, up until the saturation of the peak reference.   
+    If you plot your data with a Python code, you should get something like the image below. You can see the voltages follow the reference, up until the saturation of the peak reference.   
 
     ![result_plot](Image/result_plot.png)
-
 
 

--- a/TWIST/DC_DC/buck_voltage_mode/README.md
+++ b/TWIST/DC_DC/buck_voltage_mode/README.md
@@ -1,13 +1,13 @@
 # Buck with PID controlled output voltage
 
-A voltage mode buck converter regulates voltage by comparing the output voltage to a reference voltage. It adjusts the duty cycle of its switching signal to keep the output voltage stable. This type of converter efficiently steps down voltage levels, making it useful in various electronic devices like embedded battery charger.
+A voltage mode buck converter regulates voltage by comparing the output voltage to a reference voltage. It adjusts the duty cycle of its switching signal to keep the output voltage stable. This type of converter efficiently steps down voltage levels, making it useful in various electronic devices like an embedded battery charger.
 
 This example will implement a voltage mode buck converter to control the output.
 
-!!! warning "Are you ready to start ?"
+!!! warning "Are you ready to start?"
     Before you can run this example, you must have successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/).  
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 
 
@@ -22,7 +22,7 @@ The power flows from `VHigh` to `VLow`. The wiring diagram is shown in the figur
 ![wiring diagram](Image/wiring_diagram.png)
 
 !!! warning Hardware pre-requisites 
-    You will need :
+    You will need:
     - 1 TWIST
     - A dc power supply (20-60V)
     - A resistor (or a dc electronic load)
@@ -46,15 +46,15 @@ The tasks are executed following the diagram below.
 ![Timing diagram](Image/timing_diagram.png)
 
 
-- **Communication Task** - Is awaken regularly to verify any keyboard activity
-- **Application Task** - This task is woken once its suspend is finished 
+- **Communication Task** - Is awakened regularly to verify any keyboard activity
+- **Application Task** - This task is woken once its suspension is finished 
 - **Critical Task** - This task is driven by the HRTIM count interrupt, where it counts a number of HRTIM switching frequency periods. In this case 100us, or 20 periods of the TWIST board 200kHz switching frequency set by default.
 
 
 
 #### Control scheme
 
-The control library is imported in platformio.ini via the line :
+The control library is imported in `platformio.ini` via the line:
 
 ```
 lib_deps=
@@ -75,7 +75,7 @@ The control diagram of the `PID` is shown in the figure below.
 
 ## Expected result
 
-This code will control `V1low` and `V2low` voltages so that they follow a `voltage_reference`, you can control this reference through platformio serial monitor. The image below shows you a snippet of the window and the button to press.
+This code will control `V1low` and `V2low` voltages so that they follow a `voltage_reference`. You can control this reference through the PlatformIO serial monitor. The image below shows you a snippet of the window and the button to press.
 
 ![serial monitor button](Image/serial_monitor_button.png)
 
@@ -83,12 +83,12 @@ When opening it for the first time, the serial monitor will give you an initiali
 
 ![serial monitor initialization](Image/serial_monitor_initialization.png)
 
-!!! tip Commands keys
+!!! tip Command keys
     - press `u` to increase the voltage
     - press `d` to decrease the voltage
     - press `h` to show the help menu
 
-Here's sequence when the help menu is activated with `h`, the power mode is then activated with `p` and finally the Twist converter is put in idle with the `i`. 
+Here's the sequence when the help menu is activated with `h`, the power mode is then activated with `p` and finally the Twist converter is put in idle with the `i`. 
 
 ![serial monitor working](Image/serial_monitor_operation.gif)
 
@@ -101,16 +101,16 @@ Here's sequence when the help menu is activated with `h`, the power mode is then
     Where: 
     - `I1` is the current in `LEG1` of the `LOW` side
     - `V1` is the voltage in `LEG1` of the `LOW` side
-    - `VREF` is the reference voltage set for `LEG1` and `LEG2`vof the `LOW` side
+    - `VREF` is the reference voltage set for `LEG1` and `LEG2` of the `LOW` side
     - `I2` is the current in `LEG1` of the `LOW` side
     - `V2` is the voltage in `LEG2` of the `LOW` side
-    - `VREF` is the reference voltage set for `LEG1` and `LEG2`vof the `LOW` side
+    - `VREF` is the reference voltage set for `LEG1` and `LEG2` of the `LOW` side
     - `IH` is the current in `LEG2` of the `LOW` side
     - `VH` is the voltage on the `HIGH` side
     - `T1` is the temperature from the NTC thermistor in `LEG1` of the `LOW` side
     - `T2` is the temperature from the NTC thermistor in `LEG2` of the `LOW` side
 
-    For instance when you retrieve this: 
+    For instance, when you retrieve this: 
 
     ```c 
     1.44:14.80:0.13:16.14:1.14:22.82:
@@ -118,7 +118,6 @@ Here's sequence when the help menu is activated with `h`, the power mode is then
 
     It means that `I1 = 1.46 A`, `V1 = 14.80 V` and so on. 
 
-    If you plot your data with a python code, you will see something similar to this: 
+    If you plot your data with a Python code, you will see something similar to this: 
 
     ![result_plot](Image/result_plot.png)
-

--- a/TWIST/DC_DC/current_ripple_measurement/README.md
+++ b/TWIST/DC_DC/current_ripple_measurement/README.md
@@ -2,15 +2,15 @@
 
 Measuring current ripple can be useful to understand if the converter is operating correctly. However, it requires an oscilloscope and a special type of probe, making it difficult to achieve. 
 
-In this example will use the embedded HAL sensor of the Twist board and multiply its time resolution by 400. To do so we will keep the converter in a stable operating condition and perform a sweep on the current measurement trigger moment. The procedure will be explained in more detail below.
+In this example, we will use the embedded Hall sensor of the Twist board and multiply its time resolution by 400. To do so we will keep the converter in a stable operating condition and perform a sweep on the current measurement trigger moment. The procedure will be explained in more detail below.
 
-We will work in open loop and at a fixed duty cyle.
+We will work in open loop and at a fixed duty cycle.
 
 !!! warning 
     This is a very advanced example. Please take your time to execute it.
 
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 The circuit diagram of the board is shown in the image below.
 
@@ -23,10 +23,10 @@ The power flows from `VHigh` to `VLow`. The wiring diagram is shown in the figur
 
 
 !!! warning Hardware pre-requisites 
-    You will need :
+    You will need:
     - 1 TWIST
-    - A dc power supply (20-60V)
-    - A resistor (or a dc electronic load)
+    - A DC power supply (20-60 V)
+    - A resistor (or a DC electronic load)
 
 
 ## Main Structure
@@ -79,7 +79,7 @@ The code structure is as follows:
             break;
     ```
 
-- **Application Task** - Handles the `MODE`, activates the LED and prints data on the serial port. It calls the data dump if the trigger retrieve has been activated.
+- **Application Task** - Handles the `MODE`, activates the LED and prints data on the serial port. It calls the data dump if the trigger retrieval has been activated.
 
 - **Critical Task** - Handles the `MODE`, sets power ON/OFF, it updates the `duty_cycle` of both legs and it handles the current measurement trigger sweep. 
     The trigger sweep is performed with the following code:
@@ -109,8 +109,8 @@ The tasks are executed following the diagram below.
 ![Timing diagram](Image/timing_diagram.svg)
 
 
-- **Communication Task** - Is awaken regularly to verify any keyboard activity
-- **Application Task** - This task is woken once its suspend is finished 
+- **Communication Task** - Is awakened regularly to verify any keyboard activity
+- **Application Task** - This task is woken once its suspension is finished 
 - **Critical Task** - This task is driven by the HRTIM count interrupt, where it counts a number of HRTIM switching frequency periods. In this case 100us, or 20 periods of the TWIST board 200kHz switching frequency set by default.
 
 ### Control diagram
@@ -126,12 +126,12 @@ In this example you will need to dig deeper in the code to properly observe the 
 
 ### Change the modulation type.
 
-To rebuild the current waveform, we will use the `trig_ratio` variable to will peform a sweep on the moment the measurement is done in comparison with the carrier ramp. The image below illustrate how these changes are made for three different measurement instants. Notice the duty cycle is constant. 
+To rebuild the current waveform, we will use the `trig_ratio` variable to perform a sweep on the moment the measurement is done in comparison with the carrier ramp. The image below illustrates how these changes are made for three different measurement instants. Notice the duty cycle is constant. 
 
 ![Measurement sweep](Image/left_aligned_ADC_sweep.gif)
 
 
-!!! warning We have a problem 
+!!! warning We have a problem
 
     By default, the Twist boards operate in the `Center_Aligned` mode. Its carrier is different as shown in the image below. 
 
@@ -192,7 +192,7 @@ In the `zephyr/boards/shields/twist/twist_v1_4_1.overlay`, change modulation as 
 
 Build the code and upload it to your Twist board.
 
-!!! tip Finger in the trigger    
+!!! tip Finger on the trigger
 
     To capture the current ripple you have to follow these steps:
     - press the **`p`** key to go in `POWER_MODE`
@@ -220,7 +220,7 @@ In the code there's some parameters you can change:
 
 ## Plot the results
 
-Your `.png` file is used for a quick analysis of the results. For a better experience, you can plot the data using a platformio action. 
+Your `.png` file is used for a quick analysis of the results. For a better experience, you can plot the data using a PlatformIO action. 
 
 Follow these steps as in the image below: 
 - Click on the alien

--- a/TWIST/DC_DC/independent/README.md
+++ b/TWIST/DC_DC/independent/README.md
@@ -7,13 +7,13 @@ The Twist board has two different legs, which allows it to generate two differen
 
 This example will implement two independent power outputs, each with its own voltage reference.
 
-!!! warning "Are you ready to start ?"
+!!! warning "Are you ready to start?"
     Before you can run this example:
     - you **must** have successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/).
     - ideally, you should have successfully gone through our [Voltage Mode Example](https://docs.owntech.org/latest/examples/TWIST/DC_DC/buck_voltage_mode/)  
 
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 The circuit diagram of the example is shown in the image below.
 
@@ -26,10 +26,10 @@ The power flows from `VHigh` to both `VLow1` and `VLow2` independently. The wiri
 
 
 !!! warning Hardware pre-requisites 
-    You will need :
+    You will need:
     - 1 TWIST
-    - A dc power supply (20-60V)
-    - A resistor (or a dc electronic load)
+    - A DC power supply (20-60 V)
+    - A resistor (or a DC electronic load)
 
 
 ## Main Structure
@@ -40,7 +40,7 @@ The `main.cpp` structure is shown in the image below.
 
 The code structure is as follows:
 - On the top of the code some initialization functions take place.
-- **Setup Routine** - calls functions that set the hardware and software. Notice that it creates 2 dintinct PID controllers. 
+- **Setup Routine** - calls functions that set the hardware and software. Notice that it creates 2 distinct PID controllers. 
 
     ```cpp
     /* Initialize buck with current mode*/
@@ -65,8 +65,8 @@ The tasks are executed following the diagram below.
 ![Timing diagram](Image/timing_diagram.png)
 
 
-- **Communication Task** - Is awaken regularly to verify any keyboard activity
-- **Application Task** - This task is woken once its suspend is finished 
+- **Communication Task** - Is awakened regularly to verify any keyboard activity
+- **Application Task** - This task is woken once its suspension is finished 
 - **Critical Task** - This task is driven by the HRTIM count interrupt, where it counts a number of HRTIM switching frequency periods. In this case 100us, or 20 periods of the TWIST board 200kHz switching frequency set by default.
 
 
@@ -83,22 +83,22 @@ _Source : STM32 AN5497_
 
 ## Expected result
 
-This code will control the output voltage to have 15V, you can control the output voltage with platformio serial monitor. The image below shows your a snippet of the window and the button to press.
+This code will control the output voltage to have 15 V. You can control the output voltage with the PlatformIO serial monitor. The image below shows you a snippet of the window and the button to press.
 
 ![serial monitor button](Image/serial_monitor_button.png)
 
-When opening it for the first time, the serial monitor will give you an initialization message regarding the parameteres of the ADCs as shown below.  
+When opening it for the first time, the serial monitor will give you an initialization message regarding the parameters of the ADCs as shown below.  
 
 ![serial monitor initialization](Image/serial_monitor_initialization.png)
 
-!!! tip Commands keys
+!!! tip Command keys
     - press `u` to increase the voltage on `LEG1`
     - press `d` to decrease the voltage on `LEG1`
     - press `t` to increase the voltage on `LEG2`
     - press `g` to decrease the voltage on `LEG2`
     - press `h` to show the help menu
 
-Here's sequence when the help menu is activated with `h`, the power mode is then activated with `p` and finally the Twist converter is put in idle with the `i`. 
+Here's the sequence when the help menu is activated with `h`, the power mode is then activated with `p` and finally the Twist converter is put in idle with the `i`. 
 
 ![serial monitor working](Image/serial_monitor_operation.gif)
 
@@ -111,14 +111,14 @@ Here's sequence when the help menu is activated with `h`, the power mode is then
     Where: 
     - `I1` is the current in `LEG1` of the `LOW` side
     - `V1` is the voltage in `LEG1` of the `LOW` side
-    - `VREF1` is the reference voltage set for `LEG1`of the `LOW` side
+    - `VREF1` is the reference voltage set for `LEG1` of the `LOW` side
     - `I2` is the current in `LEG1` of the `LOW` side
     - `V2` is the voltage in `LEG2` of the `LOW` side
-    - `VREF2` is the reference voltage set for `LEG2`of the `LOW` side
+    - `VREF2` is the reference voltage set for `LEG2` of the `LOW` side
     - `IH` is the current in `LEG2` of the `LOW` side
     - `VH` is the voltage on the `HIGH` side
 
-    For instance when you reveive this: 
+    For instance, when you receive this: 
 
     ```c 
     0.203:1.037:1.000:0.513:2.818:2.500:0.420:14.997643
@@ -126,9 +126,8 @@ Here's sequence when the help menu is activated with `h`, the power mode is then
 
     It means that `I1 = 0.203 A`, `V1 = 1.037 V` and so on. 
 
-    If you plot your data with a python code, you should get something like the image below. You can see each voltage follow its own reference, up until saturation.   
+    If you plot your data with a Python code, you should get something like the image below. You can see each voltage follows its own reference, up until saturation.   
 
     ![result_plot](Image/result_plot.png)
-
 
 

--- a/TWIST/DC_DC/interleaved/README.md
+++ b/TWIST/DC_DC/interleaved/README.md
@@ -16,7 +16,7 @@ The waveform below shows how each switch in the image above operates and their a
 
 This example will implement interleaved operation using the two legs of the TWIST.
 
-!!! warning "Are you ready to start ?"
+!!! warning "Are you ready to start?"
     Before you can run this example, you must have successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/).  
 
 
@@ -25,22 +25,20 @@ This example will implement interleaved operation using the two legs of the TWIS
 ![schema](Image/buck_m.png)
 
 !!! warning Hardware pre-requisites 
-    You will need :
+    You will need:
     - 1 TWIST
-    - A dc power supply (20-60V)
-    - A resistor (or a dc electronic load)
+    - A DC power supply (20-60 V)
+    - A resistor (or a DC electronic load)
 
 
 ## Software setup
 
-## Software setup
-
-Locate your `platformio.ini file` in your working folder.
+Locate your `platformio.ini` file in your working folder.
 
 ![platformio.ini location](Image/platformio_ini_location.png)
 
 
-We will import `control_library` in `platformio.ini` by decommenting the line :
+We will import `control_library` in `platformio.ini` by uncommenting the line:
 
 ```ini
 lib_deps=
@@ -59,7 +57,7 @@ We can use this library to initialize a PID control with the function :
 pid.init(pid_params);
 ```
 
-the initial parameters are defined using the following lines :
+The initial parameters are defined using the following lines:
 
 ```cpp
 static Pid pid; // define a pid controller.
@@ -76,20 +74,20 @@ static PidParams pid_params(Ts, kp, Ti, Td, N, lower_bound, upper_bound);
 
 ## Expected results
 
-This code will control the output voltage to have 15V, you can control the output voltage with platformio serial monitor. The image below shows your a snippet of the window and the button to press.
+This code will control the output voltage to have 15 V. You can control the output voltage with the PlatformIO serial monitor. The image below shows you a snippet of the window and the button to press.
 
 ![serial monitor button](Image/serial_monitor_button.png)
 
-When opening it for the first time, the serial monitor will give you an initialization message regarding the parameteres of the ADCs as shown below.  
+When opening it for the first time, the serial monitor will give you an initialization message regarding the parameters of the ADCs as shown below.  
 
 ![serial monitor initialization](Image/serial_monitor_initialization.png)
 
-!!! tip Commands keys
+!!! tip Command keys
     - press `u` to increase the voltage
     - press `d` to decrease the voltage
     - press `h` to show the help menu
 
-Here's sequence when the help menu is activated with `h`, the power mode is then activated with `p` and finally the Twist converter is put in idle with the `i`. 
+Here's the sequence when the help menu is activated with `h`, the power mode is then activated with `p` and finally the Twist converter is put in idle with the `i`. 
 
 ![serial monitor working](Image/serial_monitor_operation.gif)
 
@@ -107,13 +105,11 @@ Here's sequence when the help menu is activated with `h`, the power mode is then
     - `IH` is the current in `LEG2` of the `LOW` side
     - `VH` is the voltage on the `HIGH` side
 
-    For instance when you reveive this: 
+    For instance, when you receive this: 
 
     ```c 
     1.44:14.80:0.13:16.14:1.14:22.82:
     ```
 
     It means that `I1 = 1.46 A`, `V1 = 14.80 V` and so on. 
-
-
 

--- a/TWIST/DC_DC/scope_simple_example/README.md
+++ b/TWIST/DC_DC/scope_simple_example/README.md
@@ -1,22 +1,22 @@
 # Scope simple example
 
-The scope is a powerful tool to inspect electric signals is real time. In this example we will visualize a simple step response of `LEG1` PID.
+The scope is a powerful tool to inspect electric signals in real time. In this example we will visualize a simple step response of the `LEG1` PID.
 
 This example will implement a voltage mode buck converter to control the output.
 
-!!! warning "Are you ready to start ?"
+!!! warning "Are you ready to start?"
     Before you can run this example, you must have successfully gone through our [getting started](https://docs.owntech.org/latest/core/docs/environment_setup/).  
 
-## Hardware setup and requirement
+## Hardware setup and requirements
 
 
 ![schema](Image/buck_m.png)
 
 !!! warning Hardware pre-requisites 
-    You will need :
+    You will need:
     - 1 TWIST
-    - A dc power supply (20-60V)
-    - A resistor (or a dc electronic load)
+    - A DC power supply (20-60 V)
+    - A resistor (or a DC electronic load)
 
 ## Software setup
 
@@ -36,19 +36,19 @@ The data to be saved to the scope is structured in the `setup_routine`.
     scope.start();
 
 ```
-Where the voltages and currents of `LEG1` and `LEG2`, the `duty_cycle` and the `V_HIGH` are going to be saved. The delay to apply the trigger is of 20% of all the measurements. 
+Where the voltages and currents of `LEG1` and `LEG2`, the `duty_cycle` and the `V_HIGH` are going to be saved. The delay to apply the trigger is 20% of all the measurements. 
 
 ## Expected result
 
-This code will control the output voltage to have 15V, you can control the output voltage with platformio serial monitor. The image below shows your a snippet of the window and the button to press.
+This code will control the output voltage to have 15 V. You can control the output voltage with the PlatformIO serial monitor. The image below shows you a snippet of the window and the button to press.
 
 ![serial monitor button](Image/serial_monitor_button.png)
 
-When opening it for the first time, the serial monitor will give you an initialization message regarding the parameteres of the ADCs as shown below.  
+When opening it for the first time, the serial monitor will give you an initialization message regarding the parameters of the ADCs as shown below.  
 
 ![serial monitor initialization](Image/serial_monitor_initialization.png)
 
-!!! tip Commands keys
+!!! tip Command keys
     - press `u` to increase the voltage
     - press `d` to decrease the voltage
     - press `a` to increase the voltage step to be applied
@@ -71,7 +71,6 @@ When opening it for the first time, the serial monitor will give you an initiali
     - `V2` is the voltage in `LEG2` of the `LOW` side
     - `IH` is the current in `LEG2` of the `LOW` side
     - `VH` is the voltage on the `HIGH` side
-    - `VREF` is the reference voltage set for `LEG1` and `LEG2`vof the `LOW` side which is applied during `POWER` mode.
+    - `VREF` is the reference voltage set for `LEG1` and `LEG2` of the `LOW` side which is applied during `POWER` mode.
     - `VSTEP` is the size of the voltage step to be applied for the test. 
-
 

--- a/TWIST/Microgrid/AC_client_server/README.md
+++ b/TWIST/Microgrid/AC_client_server/README.md
@@ -18,28 +18,28 @@ The CLIENT inverter receives the current reference and frequency signals from th
 
 ![TWIST Schema](Image/schema_MS_TWIST.png)
 
-you will need :
+You will need:
 
-- Two Twist
+- Two TWIST boards
 - A **40V** DC power supply
 - A **30Ω** resistive load
-- A RJ45 cable
+- An RJ45 cable
 
-## Instruction to flash the code, and use python script
+## Instructions to flash the code, and use the Python script
 
 This example depends on two libraries:
 
 1. control_library
 2. ScopeMimicry
 
-To use them, you have to add the following lines in platformio.ini file:
+To use them, you have to add the following lines in the `platformio.ini` file:
 ```
 lib_deps=
     control_library = https://github.com/owntech-foundation/control_library.git
     scope = https://github.com/owntech-foundation/scopemimicry.git 
 ```
 
-In src/main.cpp at the line n. 48 you have a macro that defines wether you are flashing the server or the client.
+In `src/main.cpp` at line 48 you have a macro that defines whether you are flashing the server or the client.
 
 To flash the server, choose :
 
@@ -61,28 +61,28 @@ There is also a current gain to control the current reference sent to the CLIENT
 tx_data.consigne.Iref_fromSERVER = k_gain*I1_low_value;
 ```
 
-This allows you to increase or deacrese the current of the CLIENT. To increase the current gain, in the serial monitor press `l` to decrease it press `m`.
+This allows you to increase or decrease the current of the CLIENT. To increase the current gain, in the serial monitor press `l`; to decrease it press `m`.
 
-### To view some variables.
-After stop i.e. in IDLE mode you can retrieve some data by pressing 'r'. It calls a
-function `dump_scope_datas()` which send to the console variables recorded during
+### To view some variables
+After stopping, i.e. in IDLE mode, you can retrieve some data by pressing `r`. It calls a
+function `dump_scope_datas()` which sends to the console variables recorded during
 the power flow phase.
 
-But before running, you have to add one line in the file `platfomio.ini`
+But before running, you have to add one line in the file `platformio.ini`
 
 ```ini
 monitor_filters = recorded_datas
 ```
 
-And you have put the python script `filter_datas_recorded.py` in a `monitor` directory
-which must be in you parent project directory. Then the script should capture the
-console stream to put it in a txt file named `year-month-day_hour_minutes_secondes_record.txt`.
+And you have to put the Python script `filter_datas_recorded.py` in a `monitor` directory
+which must be in your parent project directory. Then the script should capture the
+console stream to put it in a TXT file named `year-month-day_hour_minutes_seconds_record.txt`.
 
-These files can be plotted using the `plot_data.py` python script if you have the
+These files can be plotted using the `plot_data.py` Python script if you have the
 `matplotlib` and `numpy` modules installed.
 
 ## Expected result
 
-If you set up correctly the project, you should have server and client output current in phase together.
+If you set up the project correctly, you should have server and client output current in phase together.
 
 ![Result](Image/SC_result.png)

--- a/TWIST/Microgrid/AC_peer_to_peer/README.md
+++ b/TWIST/Microgrid/AC_peer_to_peer/README.md
@@ -22,17 +22,17 @@ A **proportional resonant** is used to keep the input alternative current in pha
 ![twist](Image/schema_P2P_TWIST.png)
 
 
-You will need :
+You will need:
 
-- Two Twist
+- Two TWIST boards
 - A **50V** DC power supply (input voltage for the inverter)
-- A **6V** DC power supply (external sensors/drivers suply for the synchronous rectifier)
+- A **6 V** DC power supply (external sensors/drivers supply for the synchronous rectifier)
 - A **115Ω** resistive load
--  A RJ45 cable
+- An RJ45 cable
 
 It is important to check that the boards you are using have the correct voltage and current measures since they'll be used to compute the duty cycle.
 
-## Instruction to flash the code, and view some results
+## Instructions to flash the code, and view some results
 
 
 ### To flash the code
@@ -42,14 +42,14 @@ This example depends on two libraries:
 1. control_library
 2. ScopeMimicry
 
-To use them, you have to add the following lines in platformio.ini file:
+To use them, you have to add the following lines in the `platformio.ini` file:
 ```
 lib_deps=
     control_library = https://github.com/owntech-foundation/control_library.git
     scope = https://github.com/owntech-foundation/scopemimicry.git 
 ```
 
-In src/main.cpp at the line n. 48 you have a macro that defines wether you are flashing the inverter or the synchronous rectifier.
+In `src/main.cpp` at line 48 you have a macro that defines whether you are flashing the inverter or the synchronous rectifier.
 
 To flash the inverter, choose :
 
@@ -63,18 +63,18 @@ To flash the synchronous rectifier, choose :
 #define CONSUMER
 ```
 
-Here P_ref = 20W to have a 14V output DC voltage. You can change this value in line 87 of src/main.cpp file.
+Here P_ref = 20 W to have a 14 V output DC voltage. You can change this value on line 87 of the `src/main.cpp` file.
 
 After that, connect to the inverter serial monitor and press `p` to start power flow. Press `i` to stop.
 
-### To view some variables.
+### To view some variables
 While running, press `t` to trigger the scope.
-After stop i.e. in IDLE mode you can retrieve some data by pressing `r`. 
+After stopping, i.e. in IDLE mode, you can retrieve some data by pressing `r`. 
 
 
 ## Expected results
 
-If everything goes well you'll have 47V delivered to the resistor.
+If everything goes well, you'll have 47 V delivered to the resistor.
 
 Here are some results for Vdc and Idc :
 ![DC side result](Image/P2P-DCside_m.png)
@@ -84,6 +84,6 @@ And for Vac and Iac :
 ![AC side result](Image/P2p-AcSide_m.png)
 
 
-By using the python script you can also watch MCU internal variables :
+By using the Python script you can also watch MCU internal variables:
 
 ![MCU values](Image/ADC_result_P2P.png)

--- a/TWIST/Microgrid/DC_client_server/README.md
+++ b/TWIST/Microgrid/DC_client_server/README.md
@@ -12,16 +12,16 @@ This code example demonstrates a current control experiment utilizing analog com
 - Compensation control is utilized to equilibrate current between different legs of the system. [compensation control](https://gitlab.laas.fr/afarahhass/Test-Controle/-/tree/main_CurrentMode_EqulibrateCurrent)
 
 
-| Connexion diagram | Microgrid structure |
+| Connection diagram | Microgrid structure |
 | ------ | ------ |
 | ![schema_com](Image/Analogique.png) | ![schema_com](Image/Maitre.png)|
 
 
 To run this example you would need:
-1. a Voltage Source fixed at ~30V 
-2. 2 Twist boards 
+1. a voltage source fixed at ~30 V 
+2. 2 TWIST boards 
 3. 1 RJ45 cable to make the communication link between boards.
-4. A variable resistive load between approximatively 6 and 12 Ohm.
+4. A variable resistive load between approximately 6 and 12 ohms.
 
 ## Communication Modules
 
@@ -44,7 +44,7 @@ Synchronization modules ensure that PWM signals are aligned and coordinated betw
 
    Replace this macro with one of the following options based on the board you are flashing:
 
-   For a `AUXILIARY` board:
+   For an `AUXILIARY` board:
    ```cpp
    #define AUXILIARY
    ```
@@ -69,5 +69,4 @@ Synchronization modules ensure that PWM signals are aligned and coordinated betw
 ## Conclusion
 
 This code example showcases a current control experiment that employs analog communication between a `MAIN` board and multiple `AUXILIARY` boards. By following the provided instructions and flashing the appropriate code, you can simulate and observe the regulation and synchronization of current injection into an electrical network. The combination of voltage control, current control, analog communication, and synchronization modules results in an efficient and coordinated system for current regulation.
-
 

--- a/TWIST/Microgrid/DC_droop/README.md
+++ b/TWIST/Microgrid/DC_droop/README.md
@@ -1,4 +1,4 @@
-Title: Parallel Power Conversion Experiment - Code Example
+# Parallel Power Conversion Experiment - Code Example
 
 ## Overview
 
@@ -10,7 +10,7 @@ This code example demonstrates an experiment involving three power converters co
 - Each power converter operates in voltage control mode and performs power conversion in buck mode.
 - Individual droop factors of 1.2, 1.1, and 1.6 are programmed for the respective cards.
 
-| Connexion diagram | Microgrid structure |
+| Connection diagram | Microgrid structure |
 | ------ | ------ |
 |   <img src="Image/droop.png" alt="Droop connexion diagram">| <img src="Image/droopss.png" alt="Microgrid structure">|
 
@@ -51,4 +51,3 @@ This code example demonstrates an experiment involving three power converters co
 ## Conclusion
 
 By following the provided guidelines and uploading the code to the power cards, you can emulate and study the dynamics of parallel power conversion in buck mode. This experiment allows you to investigate the impact of varied droop factors on voltage regulation and observe how the power cards work together in parallel to provide power to the DC bus. The combination of voltage control, buck mode operation, and unique droop factors contributes to an efficient and synchronized power conversion system.
-

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "OwnTech_Examples",
-    "version": "0.0.2",
+    "version": "0.5.0",
     "description": "A library that contains OwnTech Power API examples",
     "keywords": "Power, Control, OwnTech",
     "repository":
@@ -46,283 +46,305 @@
         }
     ],
     "examples": [
-    {
-        "name": "boost_voltage_mode",
-        "title": "Voltage Mode Boost",
-        "description": "Voltage mode boost converter using PID controller for TWIST",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_DC/boost_voltage_mode",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "buck_voltage_mode",
-        "title": "Voltage Mode Buck",
-        "description": "Voltage mode buck converter using PID controller for TWIST",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_DC/buck_voltage_mode",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "buck_current_mode",
-        "title": "Current Mode Buck",
-        "description": "Peak current mode buck converter using PID controller for TWIST",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_DC/buck_current_mode",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "interleaved",
-        "title": "Interleaved",
-        "description": "Interleaved mode buck converter with PID controlled output voltage",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_DC/interleaved",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "scope_simple_example",
-        "title": "Simple scope example",
-        "description": "Simple example of triggering the scope to acquire a step response.",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_DC/scope_simple_example",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "ripple_measurement",
-        "title": "Current Ripple Measurement",
-        "description": "Current ripple measurement in buck voltage mode, by sweeping adc trigger",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_DC/current_ripple_measurement",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "AC_cient_server",
-        "title": "AC client server",
-        "description": "implementation of AC client server in microgrid",
-        "group": "Examples TWIST",
-        "base": "TWIST/Microgrid/AC_client_server",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "AC_peer_to_peer",
-        "title": "AC peer to peer",
-        "description": "implementation of AC peer to peer in microgrid",
-        "group": "Examples TWIST",
-        "base": "TWIST/Microgrid/AC_peer_to_peer",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "DC_cient_server",
-        "title": "DC client server",
-        "description": "implementation of DC client server in microgrid",
-        "group": "Examples TWIST",
-        "base": "TWIST/Microgrid/DC_client_server",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "DC_droop",
-        "title": "DC droop",
-        "description": "implementation of DC droop in microgrid",
-        "group": "Examples TWIST",
-        "base": "TWIST/Microgrid/DC_droop",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "grid_forming",
-        "title": "Grid Forming Inverter",
-        "description": "It generates an AC voltage source. Commonly, a grid-forming inverter is a device that autonomously establishes and maintains stable grid voltage and frequency.",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_AC/grid_forming",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "grid_following",
-        "title": "Grid Following Inverter",
-        "description": "It is an AC current source which follow a grid voltage. Commonly, a grid-following inverter adjusts its output to match the voltage and frequency of the existing electrical grid",
-        "group": "Examples TWIST",
-        "base": "TWIST/DC_AC/grid_following",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "python_communication_protocol",
-        "title": "Python Communication Protocol",
-        "description": "This example allows a user to control a Twist in DC-DC buck mode using a Python script.",
-        "group": "Examples TWIST",
-        "base": "TWIST/Communication/python_comm_library",
-        "files": [
-            "main.cpp",
-            "comm_script.py",
-            "README.md"
-        ]
-    },
-    {
-        "name": "can_communication",
-        "title": "CAN Communication",
-        "description": "This example deploys CAN communication of the Twist board",
-        "group": "Examples TWIST",
-        "base": "TWIST/Communication/CAN",
-        "files": [
-            "main.cpp",
-            "app.conf",
-            "README.md",
-            "user_data_objects.h"
-        ]
-    },
-    {
-        "name": "blinky",
-        "title": "Blinky LED",
-        "description": "Toggling LED",
-        "group": "Examples SPIN",
-        "base": "SPIN/LED/blinky",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "duty_cycle_setting",
-        "title": "Setting PWM duty cycle",
-        "description": "Using PWM with duty cycle",
-        "group": "Examples SPIN",
-        "base": "SPIN/PWM/duty_cycle_setting",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "multiple_pwm",
-        "title": "Setting multiple PWM",
-        "description": "Using multiple PWM with duty cycle",
-        "group": "Examples SPIN",
-        "base": "SPIN/PWM/multiple_pwm",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "phase_shift",
-        "title": "Setting PWM phase shift",
-        "description": "Setting a phase shift between two PWM",
-        "group": "Examples SPIN",
-        "base": "SPIN/PWM/phase_shift",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "burst_mode",
-        "title": "Setting Burst Mode PWM",
-        "description": "Setting pulsed mode PWM",
-        "group": "Examples SPIN",
-        "base": "SPIN/PWM/burst_mode",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "signal_generation",
-        "title": "DAC signal generation",
-        "description": "Sawtooth generation with DAC",
-        "group": "Examples SPIN",
-        "base": "SPIN/DAC/signal_generation",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "adc_software_trigger",
-        "title": "Software triggered ADC",
-        "description": "setting the adc to be trigerred by software",
-        "group": "Examples SPIN",
-        "base": "SPIN/ADC/adc_hrtim_trigger",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "adc_hrtim_trigger",
-        "title": "HRTIM triggered ADC",
-        "description": "setting the adc to be trigerred by the hrtim",
-        "group": "Examples SPIN",
-        "base": "SPIN/ADC/adc_hrtim_trigger",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "incremental_encoder",
-        "title": "Incremental encoder",
-        "description": "Using a timer with a rotary incrmental encoder",
-        "group": "Examples SPIN",
-        "base": "SPIN/TIMER/incremental_encoder",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "BLDC_hall_sensor",
-        "title": "BLDC motor with hall sensor",
-        "description": "Control a BLDC motor using hall effect sensor",
-        "group": "Examples OWNVERTER",
-        "base": "OWNVERTER/BLDC_hall_sensor",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    },
-    {
-        "name": "foc_hall_sensor",
-        "title": "Motor control using FOC and hall sensors",
-        "description": "an example which show the use of a Field Oriented Control algorithm with discrete hall sensors",
-        "group": "Examples OWNVERTER",
-        "base": "OWNVERTER/FOC_hall_sensor",
-        "files": [
-            "main.cpp",
-            "README.md"
-        ]
-    }
+        {
+            "name": "Open Loop PWM",
+            "title": "Open Loop PWM",
+            "description": "Simple open loop PWM example",
+            "group": "Examples TWIST - Basic",
+            "base": "TWIST/Basic/Open-Loop_PWM",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Voltage Mode Buck",
+            "title": "Voltage Mode Buck",
+            "description": "Voltage mode buck converter using PID controller for TWIST",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/buck_voltage_mode",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Voltage Mode Boost",
+            "title": "Voltage Mode Boost",
+            "description": "Voltage mode boost converter using PID controller for TWIST",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/boost_voltage_mode",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Current Mode Buck",
+            "title": "Current Mode Buck",
+            "description": "Peak current mode buck converter using PID controller for TWIST",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/buck_current_mode",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Interleaved",
+            "title": "Interleaved",
+            "description": "Interleaved mode buck converter with PID controlled output voltage",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/interleaved",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Independent",
+            "title": "Independent",
+            "description": "Independent mode buck converter with each leg controlled by a dedicated PID",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/independent",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Simple scope example",
+            "title": "Simple scope example",
+            "description": "Simple example of triggering the scope to acquire a step response.",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/scope_simple_example",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Current Ripple Measurement",
+            "title": "Current Ripple Measurement",
+            "description": "Current ripple measurement in buck voltage mode, by sweeping adc trigger",
+            "group": "Examples TWIST - DC-DC",
+            "base": "TWIST/DC_DC/current_ripple_measurement",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Grid Following Inverter",
+            "title": "Grid Following Inverter",
+            "description": "It is an AC current source which follow a grid voltage. Commonly, a grid-following inverter adjusts its output to match the voltage and frequency of the existing electrical grid",
+            "group": "Examples TWIST - DC-AC",
+            "base": "TWIST/DC_AC/grid_following",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Grid Forming Inverter",
+            "title": "Grid Forming Inverter",
+            "description": "It generates an AC voltage source. Commonly, a grid-forming inverter is a device that autonomously establishes and maintains stable grid voltage and frequency.",
+            "group": "Examples TWIST - DC-AC",
+            "base": "TWIST/DC_AC/grid_forming",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "CAN Communication",
+            "title": "CAN Communication",
+            "description": "This example deploys CAN communication of the Twist board",
+            "group": "Examples TWIST - COMM",
+            "base": "TWIST/Communication/CAN",
+            "files": [
+                "main.cpp",
+                "app.conf",
+                "README.md",
+                "user_data_objects.h"
+            ]
+        },
+        {
+            "name": "Python Communication Protocol",
+            "title": "Python Communication Protocol",
+            "description": "This example allows a user to control a Twist in DC-DC buck mode using a Python script.",
+            "group": "Examples TWIST - COMM",
+            "base": "TWIST/Communication/python_comm_library",
+            "files": [
+                "main.cpp",
+                "comm_script.py",
+                "README.md"
+            ]
+        },
+        {
+            "name": "AC client server",
+            "title": "AC client server",
+            "description": "implementation of AC client server in microgrid",
+            "group": "Examples TWIST - Microgrid",
+            "base": "TWIST/Microgrid/AC_client_server",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "AC peer to peer",
+            "title": "AC peer to peer",
+            "description": "implementation of AC peer to peer in microgrid",
+            "group": "Examples TWIST - Microgrid",
+            "base": "TWIST/Microgrid/AC_peer_to_peer",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "DC client server",
+            "title": "DC client server",
+            "description": "implementation of DC client server in microgrid",
+            "group": "Examples TWIST - Microgrid",
+            "base": "TWIST/Microgrid/DC_client_server",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "DC droop",
+            "title": "DC droop",
+            "description": "implementation of DC droop in microgrid",
+            "group": "Examples TWIST - Microgrid",
+            "base": "TWIST/Microgrid/DC_droop",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "BLDC motor with hall sensor",
+            "title": "BLDC motor with hall sensor",
+            "description": "Control a BLDC motor using hall effect sensor",
+            "group": "Examples OWNVERTER",
+            "base": "OWNVERTER/BLDC_hall_sensor",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Motor control using FOC and hall sensors",
+            "title": "Motor control using FOC and hall sensors",
+            "description": "an example which show the use of a Field Oriented Control algorithm with discrete hall sensors",
+            "group": "Examples OWNVERTER",
+            "base": "OWNVERTER/FOC_hall_sensor",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "HRTIM triggered ADC",
+            "title": "HRTIM triggered ADC",
+            "description": "setting the adc to be trigerred by the hrtim",
+            "group": "Examples SPIN - ADC",
+            "base": "SPIN/ADC/adc_hrtim_trigger",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Software triggered ADC",
+            "title": "Software triggered ADC",
+            "description": "setting the adc to be trigerred by software",
+            "group": "Examples SPIN - ADC",
+            "base": "SPIN/ADC/adc_software_trigger",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "DAC signal generation",
+            "title": "DAC signal generation",
+            "description": "Sawtooth generation with DAC",
+            "group": "Examples SPIN - DAC",
+            "base": "SPIN/DAC/signal_generation",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Incremental encoder",
+            "title": "Incremental encoder",
+            "description": "Using a timer with a rotary incrmental encoder",
+            "group": "Examples SPIN - TIMER",
+            "base": "SPIN/TIMER/incremental_encoder",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Blinky LED",
+            "title": "Blinky LED",
+            "description": "Toggling LED",
+            "group": "Examples SPIN - LED",
+            "base": "SPIN/LED/blinky",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Setting Burst Mode PWM",
+            "title": "Setting Burst Mode PWM",
+            "description": "Setting pulsed mode PWM",
+            "group": "Examples SPIN - PWM",
+            "base": "SPIN/PWM/burst_mode",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Setting PWM duty cycle",
+            "title": "Setting PWM duty cycle",
+            "description": "Using PWM with duty cycle",
+            "group": "Examples SPIN - PWM",
+            "base": "SPIN/PWM/duty_cycle_setting",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Setting multiple PWM",
+            "title": "Setting multiple PWM",
+            "description": "Using multiple PWM with duty cycle",
+            "group": "Examples SPIN - PWM",
+            "base": "SPIN/PWM/multiple_pwm",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        },
+        {
+            "name": "Setting PWM phase shift",
+            "title": "Setting PWM phase shift",
+            "description": "Setting a phase shift between two PWM",
+            "group": "Examples SPIN - PWM",
+            "base": "SPIN/PWM/phase_shift",
+            "files": [
+                "main.cpp",
+                "README.md"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
I've updated the organization of the list of examples. This way we have a more controlled and readeable example base. 

It looks like this: 

<img width="298" height="637" alt="image" src="https://github.com/user-attachments/assets/b8c5776f-00c4-45df-af01-10187db82476" />

to test: 

replace owntech_examples = https://github.com/owntech-foundation/examples.git
 by owntech_examples = https://github.com/luizvilla/examples.git#name_update
 
 in platformio, click on the top
<img width="751" height="82" alt="image" src="https://github.com/user-attachments/assets/0b8bc132-a6f3-4b5c-85d4-7ecf422c675e" />

and type 

```
>Developer:Reload Window 
```
The new example structure should appear

I did not update the readme of the examples